### PR TITLE
Removing the requirment for optional attributes to have a value

### DIFF
--- a/src/TensorFlowNET.Core/Operations/OpDefLibrary.cs
+++ b/src/TensorFlowNET.Core/Operations/OpDefLibrary.cs
@@ -160,15 +160,18 @@ namespace Tensorflow
 
                 // Convert attr values to AttrValue protos.
                 var attr_protos = new Dictionary<string, AttrValue>();
-                foreach (var attr_def in op_def.Attr)
+                foreach (AttrDef attr_def in op_def.Attr)
                 {
                     var key = attr_def.Name;
-                    var value = attrs[key];
-
-                    if (!attrs.ContainsKey(key))
-                        Console.WriteLine($"_apply_op_helper: key '{key}' is not found in '{op_def.Name}' operation's attr_def.");
-
-                    attr_protos[key] = SetAttrValue(op_def, attr_def, value);
+                    if (attrs.ContainsKey(key))
+                    {
+                        attr_protos[key] = SetAttrValue(op_def, attr_def, attrs[key]);
+                    } else {
+                        if (attr_def.DefaultValue == null)
+                        {
+                            throw new TypeError("Missing required positional argument " + key);
+                        }
+                    }
                 }
 
                 attrs.Clear();


### PR DESCRIPTION
Removing the line `var value = attrs[key];` removes the requirement for optional attributes to have a value.
Adding the check if the attr_def has a default value adds the check to ensure required attributes need a value.

Note that the behavior of Tensorflow in Python collects a list of missing attributes where as the implementation here throws a TypeError on the first missing required parameter (including inputs).

This isn't so much of a problem when using a Type Safe wrapper as it becomes difficult to pass in non-conforming attributes.