### PR TITLE
Added transparent dtype conversion to feed_dict

### DIFF
--- a/src/TensorFlowNET.Core/Tensors/TensorConverter.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorConverter.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Threading.Tasks;
+using NumSharp;
+using NumSharp.Backends;
+using NumSharp.Utilities;
+
+namespace Tensorflow
+{
+    /// <summary>
+    ///     Provides various methods to conversion between types and <see cref="Tensor"/>.
+    /// </summary>
+    public static class TensorConverter
+    {
+        /// <summary>
+        ///     Convert given <see cref="Array"/> to <see cref="Tensor"/>.
+        /// </summary>
+        /// <param name="nd">The ndarray to convert, can be regular, jagged or multi-dim array.</param>
+        /// <param name="astype">Convert <see cref="Array"/> to given <paramref name="astype"/> before inserting it into a <see cref="Tensor"/>.</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public static Tensor ToTensor(NDArray nd, TF_DataType? astype = null)
+        {
+            return new Tensor(astype == null ? nd : nd.astype(astype.Value.as_numpy_typecode(), false));
+        }
+        
+        /// <summary>
+        ///     Convert given <see cref="NDArray"/> to <see cref="Tensor"/>.
+        /// </summary>
+        /// <param name="nd">The ndarray to convert.</param>
+        /// <param name="astype">Convert <see cref="Array"/> to given <paramref name="astype"/> before inserting it into a <see cref="Tensor"/>.</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public static Tensor ToTensor(NDArray nd, NPTypeCode? astype = null)
+        {
+            return new Tensor(astype == null ? nd : nd.astype(astype.Value, false));
+        }
+        
+        /// <summary>
+        ///     Convert given <see cref="Array"/> to <see cref="Tensor"/>.
+        /// </summary>
+        /// <param name="array">The array to convert, can be regular, jagged or multi-dim array.</param>
+        /// <param name="astype">Convert <see cref="Array"/> to given <paramref name="astype"/> before inserting it into a <see cref="Tensor"/>.</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public static Tensor ToTensor(Array array, TF_DataType? astype = null)
+        {
+            if (array == null) throw new ArgumentNullException(nameof(array));
+            var arrtype = array.ResolveElementType();
+
+            var astype_type = astype?.as_numpy_dtype() ?? arrtype;
+            if (astype_type == arrtype)
+            {
+                //no conversion required
+                if (astype == TF_DataType.TF_STRING)
+                {
+                    throw new NotSupportedException(); //TODO! when string is fully implemented.
+                }
+
+                if (astype == TF_DataType.TF_INT8)
+                {
+                    if (array.Rank != 1 || array.GetType().GetElementType()?.IsArray == true) //is multidim or jagged
+                        array = Arrays.Flatten(array);
+
+                    return new Tensor((sbyte[]) array);
+                }
+
+                //is multidim or jagged, if so - use NDArrays constructor as it records shape.
+                if (array.Rank != 1 || array.GetType().GetElementType().IsArray)
+                    return new Tensor(new NDArray(array));
+
+#if _REGEN
+		        #region Compute
+		        switch (arrtype)
+		        {
+			        %foreach supported_dtypes,supported_dtypes_lowercase%
+			        case NPTypeCode.#1: return new Tensor((#2[])arr);
+			        %
+			        default:
+				        throw new NotSupportedException();
+		        }
+		        #endregion
+#else
+
+                #region Compute
+
+                switch (arrtype.GetTypeCode())
+                {
+                    case NPTypeCode.Boolean: return new Tensor((bool[]) array);
+                    case NPTypeCode.Byte: return new Tensor((byte[]) array);
+                    case NPTypeCode.Int16: return new Tensor((short[]) array);
+                    case NPTypeCode.UInt16: return new Tensor((ushort[]) array);
+                    case NPTypeCode.Int32: return new Tensor((int[]) array);
+                    case NPTypeCode.UInt32: return new Tensor((uint[]) array);
+                    case NPTypeCode.Int64: return new Tensor((long[]) array);
+                    case NPTypeCode.UInt64: return new Tensor((ulong[]) array);
+                    case NPTypeCode.Char: return new Tensor((char[]) array);
+                    case NPTypeCode.Double: return new Tensor((double[]) array);
+                    case NPTypeCode.Single: return new Tensor((float[]) array);
+                    default:
+                        throw new NotSupportedException();
+                }
+
+                #endregion
+
+#endif
+            } else
+            {
+                //conversion is required.
+                //by this point astype is not null.
+
+                //flatten if required
+                if (array.Rank != 1 || array.GetType().GetElementType()?.IsArray == true) //is multidim or jagged
+                    array = Arrays.Flatten(array);
+
+                try
+                {
+                    return ToTensor(
+                        ArrayConvert.To(array, astype.Value.as_numpy_typecode()),
+                        null
+                    );
+                } catch (NotSupportedException)
+                {
+                    //handle dtypes not supported by ArrayConvert
+                    var ret = Array.CreateInstance(astype_type, array.LongLength);
+                    Parallel.For(0, ret.LongLength, i => ret.SetValue(Convert.ChangeType(array.GetValue(i), astype_type), i));
+                    return ToTensor(ret, null);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Convert given <see cref="Array"/> to <see cref="Tensor"/>.
+        /// </summary>
+        /// <param name="constant">The constant scalar to convert</param>
+        /// <param name="astype">Convert <paramref name="constant"/> to given <paramref name="astype"/> before inserting it into a <see cref="Tensor"/>.</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public static Tensor ToTensor<T>(T constant, TF_DataType? astype = null) where T : unmanaged
+        {
+            //was conversion requested?
+            if (astype == null)
+            {
+                //No conversion required
+                var constantType = typeof(T).as_dtype();
+                if (constantType == TF_DataType.TF_INT8)
+                    return new Tensor((sbyte) (object) constant);
+
+                if (constantType == TF_DataType.TF_STRING)
+                    return new Tensor((string) (object) constant);
+
+#if _REGEN
+		    #region Compute
+		    switch (InfoOf<T>.NPTypeCode)
+		    {
+			    %foreach supported_dtypes,supported_dtypes_lowercase%
+			    case NPTypeCode.#1: return new Tensor((#2)(object)constant);
+			    %
+			    default:
+				    throw new NotSupportedException();
+		    }
+		    #endregion
+#else
+
+                #region Compute
+
+                switch (InfoOf<T>.NPTypeCode)
+                {
+                    case NPTypeCode.Boolean: return new Tensor((bool) (object) constant);
+                    case NPTypeCode.Byte: return new Tensor((byte) (object) constant);
+                    case NPTypeCode.Int16: return new Tensor((short) (object) constant);
+                    case NPTypeCode.UInt16: return new Tensor((ushort) (object) constant);
+                    case NPTypeCode.Int32: return new Tensor((int) (object) constant);
+                    case NPTypeCode.UInt32: return new Tensor((uint) (object) constant);
+                    case NPTypeCode.Int64: return new Tensor((long) (object) constant);
+                    case NPTypeCode.UInt64: return new Tensor((ulong) (object) constant);
+                    case NPTypeCode.Char: return new Tensor(Converts.ToByte(constant));
+                    case NPTypeCode.Double: return new Tensor((double) (object) constant);
+                    case NPTypeCode.Single: return new Tensor((float) (object) constant);
+                    default:
+                        throw new NotSupportedException();
+                }
+
+                #endregion
+#endif
+            }
+
+            //conversion required
+
+            if (astype == TF_DataType.TF_INT8)
+                return new Tensor(Converts.ToSByte(constant));
+
+            if (astype == TF_DataType.TF_STRING)
+                return new Tensor(Converts.ToString(constant));
+
+            var astype_np = astype?.as_numpy_typecode();
+
+#if _REGEN
+		    #region Compute
+		    switch (astype_np)
+		    {
+			    %foreach supported_dtypes,supported_dtypes_lowercase%
+			    case NPTypeCode.#1: return new Tensor(Converts.To#1(constant));
+			    %
+			    default:
+				    throw new NotSupportedException();
+		    }
+		    #endregion
+#else
+
+		    #region Compute
+		    switch (astype_np)
+		    {
+			    case NPTypeCode.Boolean: return new Tensor(Converts.ToBoolean(constant));
+			    case NPTypeCode.Byte: return new Tensor(Converts.ToByte(constant));
+			    case NPTypeCode.Int16: return new Tensor(Converts.ToInt16(constant));
+			    case NPTypeCode.UInt16: return new Tensor(Converts.ToUInt16(constant));
+			    case NPTypeCode.Int32: return new Tensor(Converts.ToInt32(constant));
+			    case NPTypeCode.UInt32: return new Tensor(Converts.ToUInt32(constant));
+			    case NPTypeCode.Int64: return new Tensor(Converts.ToInt64(constant));
+			    case NPTypeCode.UInt64: return new Tensor(Converts.ToUInt64(constant));
+			    case NPTypeCode.Char: return new Tensor(Converts.ToByte(constant));
+			    case NPTypeCode.Double: return new Tensor(Converts.ToDouble(constant));
+			    case NPTypeCode.Single: return new Tensor(Converts.ToSingle(constant));
+			    default:
+				    throw new NotSupportedException();
+		    }
+		    #endregion
+#endif
+        }
+
+                /// <summary>
+        ///     Convert given <see cref="Array"/> to <see cref="Tensor"/>.
+        /// </summary>
+        /// <param name="constant">The constant scalar to convert</param>
+        /// <param name="astype">Convert <paramref name="constant"/> to given <paramref name="astype"/> before inserting it into a <see cref="Tensor"/>.</param>
+        /// <exception cref="NotSupportedException"></exception>
+        public static Tensor ToTensor(string constant, TF_DataType? astype = null)
+        {
+            switch (astype)
+            {
+                //was conversion requested?
+                case null:
+                case TF_DataType.TF_STRING:
+                    return new Tensor(constant);
+                //conversion required
+                case TF_DataType.TF_INT8:
+                    return new Tensor(Converts.ToSByte(constant));
+                default:
+                {
+                    var astype_np = astype?.as_numpy_typecode();
+
+#if _REGEN
+		            #region Compute
+		            switch (astype_np)
+		            {
+			            %foreach supported_dtypes,supported_dtypes_lowercase%
+			            case NPTypeCode.#1: return new Tensor(Converts.To#1(constant));
+			            %
+			            default:
+				            throw new NotSupportedException();
+		            }
+		            #endregion
+#else
+
+                    #region Compute
+                    switch (astype_np)
+                    {
+                        case NPTypeCode.Boolean: return new Tensor(Converts.ToBoolean(constant));
+                        case NPTypeCode.Byte: return new Tensor(Converts.ToByte(constant));
+                        case NPTypeCode.Int16: return new Tensor(Converts.ToInt16(constant));
+                        case NPTypeCode.UInt16: return new Tensor(Converts.ToUInt16(constant));
+                        case NPTypeCode.Int32: return new Tensor(Converts.ToInt32(constant));
+                        case NPTypeCode.UInt32: return new Tensor(Converts.ToUInt32(constant));
+                        case NPTypeCode.Int64: return new Tensor(Converts.ToInt64(constant));
+                        case NPTypeCode.UInt64: return new Tensor(Converts.ToUInt64(constant));
+                        case NPTypeCode.Char: return new Tensor(Converts.ToByte(constant));
+                        case NPTypeCode.Double: return new Tensor(Converts.ToDouble(constant));
+                        case NPTypeCode.Single: return new Tensor(Converts.ToSingle(constant));
+                        default:
+                            throw new NotSupportedException();
+                    }
+                    #endregion
+#endif
+                }
+            }
+        }
+
+    }
+}

--- a/src/TensorFlowNET.Core/Tensors/dtypes.cs
+++ b/src/TensorFlowNET.Core/Tensors/dtypes.cs
@@ -45,6 +45,8 @@ namespace Tensorflow
                     return typeof(bool);
                 case TF_DataType.TF_UINT8:
                     return typeof(byte);
+                case TF_DataType.TF_INT8:
+                    return typeof(sbyte);
                 case TF_DataType.TF_INT64:
                     return typeof(long);
                 case TF_DataType.TF_UINT64:

--- a/test/TensorFlowNET.UnitTest/SessionTest.cs
+++ b/test/TensorFlowNET.UnitTest/SessionTest.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using FluentAssertions;
 using Google.Protobuf;
+using NumSharp.Backends;
 using Tensorflow;
 using Tensorflow.Util;
 using static Tensorflow.Binding;
@@ -130,6 +131,62 @@ namespace TensorFlowNET.UnitTest
                     result.Should().HaveLength(size - 5000).And.ContainAll("a");
                 }
             }
+        }
+
+        [TestMethod]
+        public void Autocast_Case1()
+        {
+            var sess = tf.Session().as_default();
+            var input = tf.placeholder(tf.float64, shape: new TensorShape(6));
+            var op = tf.reshape(input, new int[] {2, 3});
+            sess.run(tf.global_variables_initializer());
+            var ret = sess.run(op, feed_dict: (input, np.array(1, 2, 3, 4, 5, 6)));
+
+            ret.Should().BeOfType<double>().And.BeShaped(2, 3).And.BeOfValues(1, 2, 3, 4, 5, 6);
+            print(ret.dtype);
+            print(ret);
+        }
+
+        [TestMethod]
+        public void Autocast_Case2()
+        {
+            var sess = tf.Session().as_default();
+            var input = tf.placeholder(tf.float64, shape: new TensorShape(6));
+            var op = tf.reshape(input, new int[] {2, 3});
+            sess.run(tf.global_variables_initializer());
+            var ret = sess.run(op, feed_dict: (input, np.array(1, 2, 3, 4, 5, 6).astype(NPTypeCode.Single) + 0.1f));
+
+            ret.Should().BeOfType<double>().And.BeShaped(2, 3).And.BeOfValuesApproximately(0.001d, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1);
+            print(ret.dtype);
+            print(ret);
+        }
+
+        [TestMethod]
+        public void Autocast_Case3()
+        {
+            var sess = tf.Session().as_default();
+            var input = tf.placeholder(tf.int16, shape: new TensorShape(6));
+            var op = tf.reshape(input, new int[] {2, 3});
+            sess.run(tf.global_variables_initializer());
+            var ret = sess.run(op, feed_dict: (input, np.array(1, 2, 3, 4, 5, 6).astype(NPTypeCode.Single) + 0.1f));
+
+            ret.Should().BeOfType<short>().And.BeShaped(2, 3).And.BeOfValues(1, 2, 3, 4, 5, 6);
+            print(ret.dtype);
+            print(ret);
+        }
+
+        [TestMethod]
+        public void Autocast_Case4()
+        {
+            var sess = tf.Session().as_default();
+            var input = tf.placeholder(tf.@byte, shape: new TensorShape(6));
+            var op = tf.reshape(input, new int[] {2, 3});
+            sess.run(tf.global_variables_initializer());
+            var ret = sess.run(op, feed_dict: (input, np.array(1, 2, 3, 4, 5, 6).astype(NPTypeCode.Single) + 0.1f));
+
+            ret.Should().BeOfType<byte>().And.BeShaped(2, 3).And.BeOfValues(1, 2, 3, 4, 5, 6);
+            print(ret.dtype);
+            print(ret);
         }
     }
 }

--- a/test/TensorFlowNET.UnitTest/Utilities/FluentExtension.cs
+++ b/test/TensorFlowNET.UnitTest/Utilities/FluentExtension.cs
@@ -1,0 +1,1206 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using NumSharp;
+using NumSharp.Backends;
+using NumSharp.Utilities;
+
+namespace TensorFlowNET.UnitTest
+{
+    [DebuggerStepThrough]
+    public static class FluentExtension
+    {
+        public static ShapeAssertions Should(this Shape shape)
+        {
+            return new ShapeAssertions(shape);
+        }
+
+        public static NDArrayAssertions Should(this NDArray arr)
+        {
+            return new NDArrayAssertions(arr);
+        }
+
+        public static NDArrayAssertions Should(this UnmanagedStorage arr)
+        {
+            return new NDArrayAssertions(arr);
+        }
+
+        public static string ToString(this Array arr, bool flat)
+        {
+            return new NDArray(arr).ToString(flat);
+        }
+    }
+
+    [DebuggerStepThrough]
+    public class ShapeAssertions : ReferenceTypeAssertions<Shape, ShapeAssertions>
+    {
+        public ShapeAssertions(Shape instance)
+        {
+            Subject = instance;
+        }
+
+        protected override string Identifier => "shape";
+
+        public AndConstraint<ShapeAssertions> BeOfSize(int size, string because = null, params object[] becauseArgs)
+        {
+            Subject.Size.Should().Be(size, because, becauseArgs);
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> NotBeOfSize(int size, string because = null, params object[] becauseArgs)
+        {
+            Subject.Size.Should().NotBe(size, because, becauseArgs);
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> BeShaped(params int[] dimensions)
+        {
+            if (dimensions == null)
+                throw new ArgumentNullException(nameof(dimensions));
+
+            if (dimensions.Length == 0)
+                throw new ArgumentException("Value cannot be an empty collection.", nameof(dimensions));
+
+            Subject.Dimensions.Should().BeEquivalentTo(dimensions);
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> Be(Shape shape, string because = null, params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Equals(shape))
+                .FailWith($"Expected shape to be {shape.ToString()} but got {Subject.ToString()}");
+
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> BeEquivalentTo(int? size = null, int? ndim = null, ITuple shape = null)
+        {
+            if (size.HasValue)
+            {
+                BeOfSize(size.Value, null);
+            }
+
+            if (ndim.HasValue)
+                HaveNDim(ndim.Value);
+
+            if (shape != null)
+                for (int i = 0; i < shape.Length; i++)
+                {
+                    Subject.Dimensions[i].Should().Be((int) shape[i]);
+                }
+
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> NotBe(Shape shape, string because = null, params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.Equals(shape))
+                .FailWith($"Expected shape to be {shape.ToString()} but got {Subject.ToString()}");
+
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> HaveNDim(int ndim)
+        {
+            Subject.Dimensions.Length.Should().Be(ndim);
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> BeSliced()
+        {
+            Subject.IsSliced.Should().BeTrue();
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> BeScalar()
+        {
+            Subject.IsScalar.Should().BeTrue();
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> BeBroadcasted()
+        {
+            Subject.IsBroadcasted.Should().BeTrue();
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+
+        public AndConstraint<ShapeAssertions> NotBeSliced()
+        {
+            Subject.IsSliced.Should().BeFalse();
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> NotBeScalar()
+        {
+            Subject.IsScalar.Should().BeFalse();
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> NotBeBroadcasted()
+        {
+            Subject.IsBroadcasted.Should().BeFalse();
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+
+        public AndConstraint<ShapeAssertions> BeNDim(int ndim)
+        {
+            Subject.Dimensions.Length.Should().Be(ndim);
+            return new AndConstraint<ShapeAssertions>(this);
+        }
+    }
+
+    //[DebuggerStepThrough]
+    public class NDArrayAssertions : ReferenceTypeAssertions<NDArray, NDArrayAssertions>
+    {
+        public NDArrayAssertions(NDArray instance)
+        {
+            Subject = instance;
+        }
+
+        public NDArrayAssertions(UnmanagedStorage instance)
+        {
+            Subject = new NDArray(instance);
+        }
+
+        protected override string Identifier => "shape";
+
+        public AndConstraint<NDArrayAssertions> BeOfSize(int size, string because = null, params object[] becauseArgs)
+        {
+            Subject.size.Should().Be(size, because, becauseArgs);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeShaped(params int[] dimensions)
+        {
+            if (dimensions == null)
+                throw new ArgumentNullException(nameof(dimensions));
+
+            if (dimensions.Length == 0)
+                throw new ArgumentException("Value cannot be an empty collection.", nameof(dimensions));
+
+            Subject.Unsafe.Storage.Shape.Dimensions.Should().BeEquivalentTo(dimensions);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeShaped(int? size = null, int? ndim = null, ITuple shape = null)
+        {
+            if (size.HasValue)
+            {
+                BeOfSize(size.Value, null);
+            }
+
+            if (ndim.HasValue)
+                HaveNDim(ndim.Value);
+
+            if (shape != null)
+                for (int i = 0; i < shape.Length; i++)
+                {
+                    Subject.Unsafe.Storage.Shape.Dimensions[i].Should().Be((int) shape[i]);
+                }
+
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> NotBeShaped(Shape shape, string because = null, params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.Unsafe.Storage.Shape.Equals(shape))
+                .FailWith($"Expected shape to be {shape.ToString()} but got {Subject.ToString()}");
+
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> HaveNDim(int ndim)
+        {
+            Subject.Unsafe.Storage.Shape.Dimensions.Length.Should().Be(ndim);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeBroadcasted()
+        {
+            Subject.Unsafe.Storage.Shape.IsBroadcasted.Should().BeTrue();
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> NotBeBroadcasted()
+        {
+            Subject.Unsafe.Storage.Shape.IsBroadcasted.Should().BeFalse();
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeSliced()
+        {
+            Subject.Unsafe.Storage.Shape.IsSliced.Should().BeTrue();
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeScalar()
+        {
+            Subject.Unsafe.Storage.Shape.IsScalar.Should().BeTrue();
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeScalar(object value)
+        {
+            Subject.Unsafe.Storage.Shape.IsScalar.Should().BeTrue();
+            Subject.GetValue().Should().Be(value);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeOfType(NPTypeCode typeCode)
+        {
+            Subject.typecode.Should().Be(typeCode);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeOfType(Type typeCode)
+        {
+            Subject.dtype.Should().Be(typeCode);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeOfType<T>()
+        {
+            Subject.typecode.Should().Be(InfoOf<T>.NPTypeCode);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> NotBeSliced()
+        {
+            Subject.Unsafe.Storage.Shape.IsSliced.Should().BeFalse();
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> NotBeScalar()
+        {
+            Subject.Unsafe.Storage.Shape.IsScalar.Should().BeFalse();
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+
+        public AndConstraint<NDArrayAssertions> BeNDim(int ndim)
+        {
+            Subject.Unsafe.Storage.Shape.Dimensions.Length.Should().Be(ndim);
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> Be(NDArray expected)
+        {
+            Execute.Assertion
+                .ForCondition(np.array_equal(Subject, expected))
+                .FailWith($"Expected the subject and other ndarray to be equals.\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{expected.ToString(false)}");
+
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeOfValues(params object[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+
+            Subject.size.Should().Be(values.Length, "the method BeOfValues also confirms the sizes are matching with given values.");
+
+#if _REGEN
+            #region Compute
+		    switch (Subject.typecode)
+		    {
+			    %foreach supported_dtypes,supported_dtypes_lowercase%
+			    case NPTypeCode.#1: 
+                {
+                    var iter = Subject.AsIterator<#2>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+                        
+                        var expected = Convert.To#1(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: #1).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+                    break;
+                }
+			    %
+			    default:
+				    throw new NotSupportedException();
+		    }
+            #endregion
+#else
+
+            #region Compute
+
+            switch (Subject.typecode)
+            {
+                case NPTypeCode.Boolean:
+                {
+                    var iter = Subject.AsIterator<bool>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToBoolean(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Byte:
+                {
+                    var iter = Subject.AsIterator<byte>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToByte(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Byte).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int16:
+                {
+                    var iter = Subject.AsIterator<short>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToInt16(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Int16).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt16:
+                {
+                    var iter = Subject.AsIterator<ushort>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToUInt16(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: UInt16).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int32:
+                {
+                    var iter = Subject.AsIterator<int>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToInt32(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Int32).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt32:
+                {
+                    var iter = Subject.AsIterator<uint>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToUInt32(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: UInt32).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int64:
+                {
+                    var iter = Subject.AsIterator<long>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToInt64(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Int64).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt64:
+                {
+                    var iter = Subject.AsIterator<ulong>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToUInt64(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: UInt64).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Char:
+                {
+                    var iter = Subject.AsIterator<char>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToChar(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Char).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Double:
+                {
+                    var iter = Subject.AsIterator<double>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToDouble(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Double).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Single:
+                {
+                    var iter = Subject.AsIterator<float>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToSingle(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Single).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Decimal:
+                {
+                    var iter = Subject.AsIterator<decimal>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToDecimal(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Decimal).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                default:
+                    throw new NotSupportedException();
+            }
+
+            #endregion
+
+#endif
+
+
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> AllValuesBe(object val)
+        {
+#if _REGEN
+            #region Compute
+		    switch (Subject.typecode)
+		    {
+			    %foreach supported_dtypes,supported_dtypes_lowercase%
+			    case NPTypeCode.#1: 
+                {
+                    var iter = Subject.AsIterator<#2>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.To#1(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: #1).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+                    break;
+                }
+			    %
+			    default:
+				    throw new NotSupportedException();
+		    }
+            #endregion
+#else
+
+            #region Compute
+
+            switch (Subject.typecode)
+            {
+                case NPTypeCode.Boolean:
+                {
+                    var iter = Subject.AsIterator<bool>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToBoolean(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Byte:
+                {
+                    var iter = Subject.AsIterator<byte>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToByte(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Byte).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int16:
+                {
+                    var iter = Subject.AsIterator<short>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToInt16(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Int16).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt16:
+                {
+                    var iter = Subject.AsIterator<ushort>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToUInt16(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: UInt16).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int32:
+                {
+                    var iter = Subject.AsIterator<int>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToInt32(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Int32).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt32:
+                {
+                    var iter = Subject.AsIterator<uint>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToUInt32(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: UInt32).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int64:
+                {
+                    var iter = Subject.AsIterator<long>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToInt64(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Int64).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt64:
+                {
+                    var iter = Subject.AsIterator<ulong>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToUInt64(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: UInt64).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Char:
+                {
+                    var iter = Subject.AsIterator<char>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToChar(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Char).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Double:
+                {
+                    var iter = Subject.AsIterator<double>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToDouble(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Double).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Single:
+                {
+                    var iter = Subject.AsIterator<float>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToSingle(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Single).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Decimal:
+                {
+                    var iter = Subject.AsIterator<decimal>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToDecimal(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Decimal).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                default:
+                    throw new NotSupportedException();
+            }
+
+            #endregion
+
+#endif
+
+
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+
+        public AndConstraint<NDArrayAssertions> BeOfValuesApproximately(double sensitivity, params object[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+
+            Subject.size.Should().Be(values.Length, "the method BeOfValuesApproximately also confirms the sizes are matching with given values.");
+
+#if _REGEN
+            #region Compute
+		    switch (Subject.typecode)
+		    {
+			    %foreach supported_dtypes,supported_dtypes_lowercase%
+			    case NPTypeCode.#1: 
+                {
+                    var iter = Subject.AsIterator<#2>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+                        
+                        var expected = Convert.To#1(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+                    break;
+                }
+			    %
+			    default:
+				    throw new NotSupportedException();
+		    }
+            #endregion
+#else
+
+            #region Compute
+
+            switch (Subject.typecode)
+            {
+                case NPTypeCode.Boolean:
+                {
+                    var iter = Subject.AsIterator<bool>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToBoolean(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Byte:
+                {
+                    var iter = Subject.AsIterator<byte>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToByte(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int16:
+                {
+                    var iter = Subject.AsIterator<short>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToInt16(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt16:
+                {
+                    var iter = Subject.AsIterator<ushort>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToUInt16(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int32:
+                {
+                    var iter = Subject.AsIterator<int>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToInt32(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt32:
+                {
+                    var iter = Subject.AsIterator<uint>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToUInt32(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Int64:
+                {
+                    var iter = Subject.AsIterator<long>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToInt64(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.UInt64:
+                {
+                    var iter = Subject.AsIterator<ulong>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToUInt64(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs((double) (expected - nextval)) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Char:
+                {
+                    var iter = Subject.AsIterator<char>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToChar(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Double:
+                {
+                    var iter = Subject.AsIterator<double>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToDouble(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Single:
+                {
+                    var iter = Subject.AsIterator<float>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToSingle(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                case NPTypeCode.Decimal:
+                {
+                    var iter = Subject.AsIterator<decimal>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+
+                        var expected = Convert.ToDecimal(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= (decimal) sensitivity)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+
+                    break;
+                }
+
+                default:
+                    throw new NotSupportedException();
+            }
+
+            #endregion
+
+#endif
+
+
+            return new AndConstraint<NDArrayAssertions>(this);
+        }
+    }
+}


### PR DESCRIPTION
In python, Tensorflow automatically casts input dtype to the expected dtype. 
Because we use `c_api`, this autocasting should be done by our code.
#### Proof
`input` placeholder is expecting `tf.float64`, given `np.array` is `tf.int32`. This code runs without a problem.
```python
with tf.Session().as_default() as sess:
    input = tf.placeholder(tf.float64, shape=[6])
    op = tf.reshape(input, [2, 3])
    sess.run(tf.global_variables_initializer())
    ret = sess.run(op, feed_dict={input: np.array([1, 2, 3, 4, 5, 6])})

    print(ret)
```



