### PR TITLE
Added support for unknown dimension #377

### DIFF
--- a/src/TensorFlowNET.Core/APIs/tf.layers.cs
+++ b/src/TensorFlowNET.Core/APIs/tf.layers.cs
@@ -15,6 +15,8 @@
 ******************************************************************************/
 
 using System.Collections.Generic;
+using System.Linq;
+using NumSharp;
 using Tensorflow.Keras.Layers;
 using Tensorflow.Operations.Activation;
 using static Tensorflow.Binding;
@@ -182,6 +184,7 @@ namespace Tensorflow
                 string name = null,
                 string data_format = "channels_last")
             {
+                var input_shape = inputs.shape;
                 if (inputs.shape.Length == 0)
                     throw new ValueError($"Input 0 of layer flatten is incompatible with the layer: : expected min_ndim={1}, found ndim={0}. Full shape received: ()");
 
@@ -193,9 +196,25 @@ namespace Tensorflow
                     inputs = array_ops.transpose(inputs, premutation.ToArray());
                 }
 
-                var ret = array_ops.reshape(inputs, new int[] {inputs.shape[0], -1});
-                ret.set_shape(new int[] {inputs.shape[0], -1});
+                var ret = array_ops.reshape(inputs, new int[] {input_shape[0], -1});
+                ret.shape = ret.shape;
+                //ret.set_shape(compute_output_shape(ret.shape));
                 return ret;
+
+                int[] compute_output_shape(int[] inputshape)
+                {
+                    if (inputshape == null || inputshape.Length == 0)
+                        inputshape = new int[] {1};
+
+                    if (inputshape.Skip(1).All(d => d > 0))
+                    {
+                        int[] output_shape = new int[2];
+                        output_shape[0] = inputshape[0];
+                        output_shape[1] = inputshape.Skip(1).Aggregate(1, (acc, rhs) => acc*rhs); //calculate size of all the rest dimensions
+                        return output_shape;
+                    } else
+                        return new int[] {inputshape[0], -1}; //-1 == Binding.None
+                }
             }
         }
     }

--- a/src/TensorFlowNET.Core/APIs/tf.layers.cs
+++ b/src/TensorFlowNET.Core/APIs/tf.layers.cs
@@ -196,8 +196,7 @@ namespace Tensorflow
                     inputs = array_ops.transpose(inputs, premutation.ToArray());
                 }
 
-                var ret = array_ops.reshape(inputs, new int[] {input_shape[0], -1});
-                ret.shape = ret.shape;
+                var ret = array_ops.reshape(inputs, compute_output_shape(input_shape));
                 //ret.set_shape(compute_output_shape(ret.shape));
                 return ret;
 

--- a/src/TensorFlowNET.Core/Binding.Util.cs
+++ b/src/TensorFlowNET.Core/Binding.Util.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using NumSharp.Utilities;
 
 namespace Tensorflow
 {
@@ -29,9 +30,37 @@ namespace Tensorflow
     /// </summary>
     public static partial class Binding
     {
+        private static string _tostring(object obj)
+        {
+            switch (obj)
+            {
+                case NDArray nd:
+                    return nd.ToString(false);
+                case Array arr:
+                    if (arr.Rank!=1 || arr.GetType().GetElementType()?.IsArray == true)
+                        arr = Arrays.Flatten(arr);
+                    var objs = toObjectArray(arr);
+                    return $"[{string.Join(", ", objs.Select(_tostring))}]";
+                default:
+                    return obj?.ToString() ?? "null";
+            }
+
+            object[] toObjectArray(Array arr)
+            {
+                var len = arr.LongLength;
+                var ret = new object[len];
+                for (long i = 0; i < len; i++)
+                {
+                    ret[i] = arr.GetValue(i);
+                }
+
+                return ret;
+            }
+        }
+
         public static void print(object obj)
         {
-            Console.WriteLine(obj.ToString());
+            Console.WriteLine(_tostring(obj));
         }
 
         public static int len(object a)

--- a/src/TensorFlowNET.Core/Binding.cs
+++ b/src/TensorFlowNET.Core/Binding.cs
@@ -10,7 +10,13 @@ namespace Tensorflow
 
         /// <summary>
         ///     Alias to null, similar to python's None.
+        ///     For TensorShape, please use Unknown
         /// </summary>
         public static readonly object None = null;
+
+        /// <summary>
+        /// Used for TensorShape None
+        /// </summary>
+        public static readonly int Unknown = -1;
     }
 }

--- a/src/TensorFlowNET.Core/Binding.cs
+++ b/src/TensorFlowNET.Core/Binding.cs
@@ -7,5 +7,10 @@ namespace Tensorflow
     public static partial class Binding
     {
         public static tensorflow tf { get; } = New<tensorflow>();
+
+        /// <summary>
+        ///     Alias to null, similar to python's None.
+        /// </summary>
+        public static readonly object None = null;
     }
 }

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -33,7 +33,23 @@ namespace Tensorflow
         /// <summary>
         ///     Returns the size this shape represents.
         /// </summary>
-        public int size => shape.Size;
+        public int size
+        {
+            get
+            {
+                var dims = shape.Dimensions;
+                var computed = 1;
+                for (int i = 0; i < dims.Length; i++)
+                {
+                    var val = dims[i];
+                    if (val <= 0)
+                        continue;
+                    computed *= val;
+                }
+
+                return computed;
+            }
+        }
 
         public TensorShape(TensorShapeProto proto)
         {

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using NumSharp.Utilities;
 
 namespace Tensorflow
 {
@@ -62,6 +63,30 @@ namespace Tensorflow
                 case 1: shape = Shape.Vector((int) dims[0]); break;
                 case 2: shape = Shape.Matrix(dims[0], dims[1]); break;
                 default: shape = new Shape(dims); break;
+            }
+        }
+
+        /// <summary>
+        ///     An overload that can accept <see cref="Binding.None"/>.
+        /// </summary>
+        public TensorShape(params object[] dims)
+        {
+            var intdims = new int[dims.Length];
+            for (int i = 0; i < dims.Length; i++)
+            {
+                var val = dims[i];
+                if (val == Binding.None)
+                    intdims[i] = -1;
+                else
+                    intdims[i] = Converts.ToInt32(val);
+            }
+
+            switch (dims.Length)
+            {
+                case 0: shape = new Shape(new int[0]); break;
+                case 1: shape = Shape.Vector((int) intdims[0]); break;
+                case 2: shape = Shape.Matrix(intdims[0], intdims[1]); break;
+                default: shape = new Shape(intdims); break;
             }
         }
 

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -55,17 +55,6 @@ namespace Tensorflow
             }
         }
 
-        public TensorShape(params int[] dims)
-        {
-            switch (dims.Length)
-            {
-                case 0: shape = new Shape(new int[0]); break;
-                case 1: shape = Shape.Vector((int) dims[0]); break;
-                case 2: shape = Shape.Matrix(dims[0], dims[1]); break;
-                default: shape = new Shape(dims); break;
-            }
-        }
-
         /// <summary>
         ///     An overload that can accept <see cref="Binding.None"/>.
         /// </summary>

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -254,6 +254,22 @@ namespace Tensorflow
 
         public static explicit operator (int, int, int, int, int, int)(TensorShape shape) => shape.dims.Length == 6 ? (shape.dims[0], shape.dims[1], shape.dims[2], shape.dims[3], shape.dims[4], shape.dims[5]) : (0, 0, 0, 0, 0, 0);
         public static implicit operator TensorShape((int, int, int, int, int, int) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6);
+                
+        public static explicit operator (int, int, int, int, int, int, int)(TensorShape shape) => shape.dims.Length == 7 ? (shape.dims[0], shape.dims[1], shape.dims[2], shape.dims[3], shape.dims[4], shape.dims[5], shape.dims[6]) : (0, 0, 0, 0, 0, 0, 0);
+        public static implicit operator TensorShape((int, int, int, int, int, int, int) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7);
+                
+        public static explicit operator (int, int, int, int, int, int, int, int)(TensorShape shape) => shape.dims.Length == 8 ? (shape.dims[0], shape.dims[1], shape.dims[2], shape.dims[3], shape.dims[4], shape.dims[5], shape.dims[6], shape.dims[7]) : (0, 0, 0, 0, 0, 0, 0, 0);
+        public static implicit operator TensorShape((int, int, int, int, int, int, int, int) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7, dims.Item8);
+        
+        public static implicit operator TensorShape(int?[] dims) => new TensorShape(dims);
+        public static implicit operator TensorShape(int? dim) => new TensorShape(dim);
+        public static implicit operator TensorShape((object, object) dims) => new TensorShape(dims.Item1, dims.Item2);
+        public static implicit operator TensorShape((object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3);
+        public static implicit operator TensorShape((object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4);
+        public static implicit operator TensorShape((object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5);
+        public static implicit operator TensorShape((object, object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6);
+        public static implicit operator TensorShape((object, object, object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7);
+        public static implicit operator TensorShape((object, object, object, object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7, dims.Item8);
 
     }
 }

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -55,9 +55,6 @@ namespace Tensorflow
             }
         }
 
-        /// <summary>
-        ///     An overload that can accept <see cref="Binding.None"/>.
-        /// </summary>
         public TensorShape(params object[] dims)
         {
             var intdims = new int[dims.Length];

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -232,6 +232,8 @@ namespace Tensorflow
         public static implicit operator TensorShape(Shape shape) => new TensorShape((int[]) shape.Dimensions.Clone());
         public static implicit operator Shape(TensorShape shape) => new Shape((int[]) shape.dims.Clone());
         
+        public static implicit operator TensorShape(object[] dims) => new TensorShape(dims);        
+
         public static implicit operator int[](TensorShape shape) => (int[])shape.dims.Clone(); //we clone to avoid any changes
         public static implicit operator TensorShape(int[] dims) => new TensorShape(dims);
 

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -57,10 +57,36 @@ namespace Tensorflow
 
         public TensorShape(params object[] dims)
         {
-            var intdims = new int[dims.Length];
-            for (int i = 0; i < dims.Length; i++)
+            Array arr;
+
+            if (dims.Length == 1)
             {
-                var val = dims[i];
+                switch (dims[0])
+                {
+                    case int[] intarr:
+                        arr = intarr;
+                        break;
+                    case long[] longarr:
+                        arr = longarr;
+                        break;
+                    case object[] objarr:
+                        arr = objarr;
+                        break;
+                    case int _:
+                    case long _:
+                        arr = dims;
+                        break;
+                    default:
+                        Binding.print(dims);
+                        throw new ArgumentException(nameof(dims));
+                }
+            } else
+                arr = dims;
+
+            var intdims = new int[arr.Length];
+            for (int i = 0; i < arr.Length; i++)
+            {
+                var val = arr.GetValue(i);
                 if (val == Binding.None)
                     intdims[i] = -1;
                 else
@@ -69,10 +95,18 @@ namespace Tensorflow
 
             switch (dims.Length)
             {
-                case 0: shape = new Shape(new int[0]); break;
-                case 1: shape = Shape.Vector((int) intdims[0]); break;
-                case 2: shape = Shape.Matrix(intdims[0], intdims[1]); break;
-                default: shape = new Shape(intdims); break;
+                case 0:
+                    shape = new Shape(new int[0]);
+                    break;
+                case 1:
+                    shape = Shape.Vector((int) intdims[0]);
+                    break;
+                case 2:
+                    shape = Shape.Matrix(intdims[0], intdims[1]);
+                    break;
+                default:
+                    shape = new Shape(intdims);
+                    break;
             }
         }
 

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -92,6 +92,9 @@ namespace Tensorflow
                     case long _:
                         arr = dims;
                         break;
+                    case null: //==Binding.None
+                        arr = dims;
+                        break;
                     default:
                         Binding.print(dims);
                         throw new ArgumentException(nameof(dims));

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -71,61 +71,32 @@ namespace Tensorflow
             }
         }
 
-        public TensorShape(params object[] dims)
+        public TensorShape(params int[] dims)
         {
-            Array arr;
-
-            if (dims.Length == 1)
+            switch (dims.Length)
             {
-                switch (dims[0])
-                {
-                    case int[] intarr:
-                        arr = intarr;
-                        break;
-                    case long[] longarr:
-                        arr = longarr;
-                        break;
-                    case object[] objarr:
-                        arr = objarr;
-                        break;
-                    case int _:
-                    case long _:
-                        arr = dims;
-                        break;
-                    case null: //==Binding.None
-                        arr = dims;
-                        break;
-                    default:
-                        Binding.print(dims);
-                        throw new ArgumentException(nameof(dims));
-                }
-            } else
-                arr = dims;
-
-            var intdims = new int[arr.Length];
-            for (int i = 0; i < arr.Length; i++)
-            {
-                var val = arr.GetValue(i);
-                if (val == Binding.None)
-                    intdims[i] = -1;
-                else
-                    intdims[i] = Converts.ToInt32(val);
+                case 0: shape = new Shape(new int[0]); break;
+                case 1: shape = Shape.Vector((int)dims[0]); break;
+                case 2: shape = Shape.Matrix(dims[0], dims[1]); break;
+                default: shape = new Shape(dims); break;
             }
+        }
 
-            switch (intdims.Length)
+        public TensorShape(int[][] dims)
+        {
+            if(dims.Length == 1)
             {
-                case 0:
-                    shape = new Shape(new int[0]);
-                    break;
-                case 1:
-                    shape = Shape.Vector((int) intdims[0]);
-                    break;
-                case 2:
-                    shape = Shape.Matrix(intdims[0], intdims[1]);
-                    break;
-                default:
-                    shape = new Shape(intdims);
-                    break;
+                switch (dims[0].Length)
+                {
+                    case 0: shape = new Shape(new int[0]); break;
+                    case 1: shape = Shape.Vector((int)dims[0][0]); break;
+                    case 2: shape = Shape.Matrix(dims[0][0], dims[1][2]); break;
+                    default: shape = new Shape(dims[0]); break;
+                }
+            }
+            else
+            {
+                throw new NotImplementedException("TensorShape int[][] dims");
             }
         }
 
@@ -232,8 +203,6 @@ namespace Tensorflow
         public static implicit operator TensorShape(Shape shape) => new TensorShape((int[]) shape.Dimensions.Clone());
         public static implicit operator Shape(TensorShape shape) => new Shape((int[]) shape.dims.Clone());
         
-        public static implicit operator TensorShape(object[] dims) => new TensorShape(dims);        
-
         public static implicit operator int[](TensorShape shape) => (int[])shape.dims.Clone(); //we clone to avoid any changes
         public static implicit operator TensorShape(int[] dims) => new TensorShape(dims);
 
@@ -260,16 +229,5 @@ namespace Tensorflow
                 
         public static explicit operator (int, int, int, int, int, int, int, int)(TensorShape shape) => shape.dims.Length == 8 ? (shape.dims[0], shape.dims[1], shape.dims[2], shape.dims[3], shape.dims[4], shape.dims[5], shape.dims[6], shape.dims[7]) : (0, 0, 0, 0, 0, 0, 0, 0);
         public static implicit operator TensorShape((int, int, int, int, int, int, int, int) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7, dims.Item8);
-        
-        public static implicit operator TensorShape(int?[] dims) => new TensorShape(dims);
-        public static implicit operator TensorShape(int? dim) => new TensorShape(dim);
-        public static implicit operator TensorShape((object, object) dims) => new TensorShape(dims.Item1, dims.Item2);
-        public static implicit operator TensorShape((object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3);
-        public static implicit operator TensorShape((object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4);
-        public static implicit operator TensorShape((object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5);
-        public static implicit operator TensorShape((object, object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6);
-        public static implicit operator TensorShape((object, object, object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7);
-        public static implicit operator TensorShape((object, object, object, object, object, object, object, object) dims) => new TensorShape(dims.Item1, dims.Item2, dims.Item3, dims.Item4, dims.Item5, dims.Item6, dims.Item7, dims.Item8);
-
     }
 }

--- a/src/TensorFlowNET.Core/Tensors/TensorShape.cs
+++ b/src/TensorFlowNET.Core/Tensors/TensorShape.cs
@@ -109,7 +109,7 @@ namespace Tensorflow
                     intdims[i] = Converts.ToInt32(val);
             }
 
-            switch (dims.Length)
+            switch (intdims.Length)
             {
                 case 0:
                     shape = new Shape(new int[0]);

--- a/src/TensorFlowNET.Core/tensorflow.cs
+++ b/src/TensorFlowNET.Core/tensorflow.cs
@@ -63,7 +63,7 @@ namespace Tensorflow
             return gen_array_ops.placeholder(dtype, shape, name);
         }
 
-        public unsafe Tensor placeholder(TF_DataType dtype, object[] shape = null, string name = null)
+        public unsafe Tensor placeholder(TF_DataType dtype, object[] shape, string name = null)
         {
             return placeholder(dtype, new TensorShape(shape), name);
         }

--- a/src/TensorFlowNET.Core/tensorflow.cs
+++ b/src/TensorFlowNET.Core/tensorflow.cs
@@ -63,11 +63,6 @@ namespace Tensorflow
             return gen_array_ops.placeholder(dtype, shape, name);
         }
 
-        public unsafe Tensor placeholder(TF_DataType dtype, object[] shape, string name = null)
-        {
-            return placeholder(dtype, new TensorShape(shape), name);
-        }
-
         public void enable_eager_execution()
         {
             // contex = new Context();

--- a/src/TensorFlowNET.Core/tensorflow.cs
+++ b/src/TensorFlowNET.Core/tensorflow.cs
@@ -63,6 +63,11 @@ namespace Tensorflow
             return gen_array_ops.placeholder(dtype, shape, name);
         }
 
+        public unsafe Tensor placeholder(TF_DataType dtype, object[] shape = null, string name = null)
+        {
+            return placeholder(dtype, new TensorShape(shape), name);
+        }
+
         public void enable_eager_execution()
         {
             // contex = new Context();

--- a/test/TensorFlowNET.UnitTest/TensorShapeTest.cs
+++ b/test/TensorFlowNET.UnitTest/TensorShapeTest.cs
@@ -12,48 +12,48 @@ namespace TensorFlowNET.UnitTest
         [TestMethod]
         public void Case1()
         {
-            int? a = 2;
-            int? b = 3;
-            var dims = new object[] {(int?) None, a, b};
+            int a = 2;
+            int b = 3;
+            var dims = new [] { Unknown, a, b};
             new TensorShape(dims).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, 3);
         }
 
         [TestMethod]
         public void Case2()
         {
-            int? a = 2;
-            int? b = 3;
-            var dims = new object[] {(int?) None, a, b};
-            new TensorShape(new object[] {dims}).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, 3);
+            int a = 2;
+            int b = 3;
+            var dims = new[] { Unknown, a, b};
+            new TensorShape(new [] {dims}).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, 3);
         }
 
         [TestMethod]
         public void Case3()
         {
-            int? a = 2;
-            int? b = null;
-            var dims = new object[] {(int?) None, a, b};
-            new TensorShape(new object[] {dims}).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, -1);
+            int a = 2;
+            int b = Unknown;
+            var dims = new [] { Unknown, a, b};
+            new TensorShape(new [] {dims}).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, -1);
         }
 
         [TestMethod]
         public void Case4()
         {
-            TensorShape shape = (None, None);
+            TensorShape shape = (Unknown, Unknown);
             shape.GetPrivate<Shape>("shape").Should().BeShaped(-1, -1);
         }
 
         [TestMethod]
         public void Case5()
         {
-            TensorShape shape = (1, None, 3);
+            TensorShape shape = (1, Unknown, 3);
             shape.GetPrivate<Shape>("shape").Should().BeShaped(1, -1, 3);
         }
 
         [TestMethod]
         public void Case6()
         {
-            TensorShape shape = (None, 1, 2, 3, None);
+            TensorShape shape = (Unknown, 1, 2, 3, Unknown);
             shape.GetPrivate<Shape>("shape").Should().BeShaped(-1, 1, 2, 3, -1);
         }
     }

--- a/test/TensorFlowNET.UnitTest/TensorShapeTest.cs
+++ b/test/TensorFlowNET.UnitTest/TensorShapeTest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NumSharp;
+using Tensorflow;
+using static Tensorflow.Binding;
+
+namespace TensorFlowNET.UnitTest
+{
+    [TestClass]
+    public class TensorShapeTest
+    {
+        [TestMethod]
+        public void Case1()
+        {
+            int? a = 2;
+            int? b = 3;
+            var dims = new object[] {(int?) None, a, b};
+            new TensorShape(dims).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, 3);
+        }
+
+        [TestMethod]
+        public void Case2()
+        {
+            int? a = 2;
+            int? b = 3;
+            var dims = new object[] {(int?) None, a, b};
+            new TensorShape(new object[] {dims}).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, 3);
+        }
+
+        [TestMethod]
+        public void Case3()
+        {
+            int? a = 2;
+            int? b = null;
+            var dims = new object[] {(int?) None, a, b};
+            new TensorShape(new object[] {dims}).GetPrivate<Shape>("shape").Should().BeShaped(-1, 2, -1);
+        }
+
+        [TestMethod]
+        public void Case4()
+        {
+            TensorShape shape = (None, None);
+            shape.GetPrivate<Shape>("shape").Should().BeShaped(-1, -1);
+        }
+
+        [TestMethod]
+        public void Case5()
+        {
+            TensorShape shape = (1, None, 3);
+            shape.GetPrivate<Shape>("shape").Should().BeShaped(1, -1, 3);
+        }
+
+        [TestMethod]
+        public void Case6()
+        {
+            TensorShape shape = (None, 1, 2, 3, None);
+            shape.GetPrivate<Shape>("shape").Should().BeShaped(-1, 1, 2, 3, -1);
+        }
+    }
+}

--- a/test/TensorFlowNET.UnitTest/layers_test/flatten.cs
+++ b/test/TensorFlowNET.UnitTest/layers_test/flatten.cs
@@ -45,5 +45,14 @@ namespace TensorFlowNET.UnitTest.layers_test
             var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(3, 4, None, 1, 2));
             sess.run(tf.layers.flatten(input), (input, np.arange(3 * 4 * 3 * 1 * 2).reshape(3, 4, 3, 1, 2))).Should().BeShaped(3, 24);
         }
+
+        [TestMethod]
+        public void Case5()
+        {
+            var sess = tf.Session().as_default();
+
+            var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(None, 4, 3, 1, 2));
+            sess.run(tf.layers.flatten(input), (input, np.arange(3 * 4 * 3 * 1 * 2).reshape(3, 4, 3, 1, 2))).Should().BeShaped(3, 24);
+        }
     }
 }

--- a/test/TensorFlowNET.UnitTest/layers_test/flatten.cs
+++ b/test/TensorFlowNET.UnitTest/layers_test/flatten.cs
@@ -42,7 +42,7 @@ namespace TensorFlowNET.UnitTest.layers_test
         {
             var sess = tf.Session().as_default();
 
-            var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(3, 4, None, 1, 2));
+            var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(3, 4, Unknown, 1, 2));
             sess.run(tf.layers.flatten(input), (input, np.arange(3 * 4 * 3 * 1 * 2).reshape(3, 4, 3, 1, 2))).Should().BeShaped(3, 24);
         }
 
@@ -51,7 +51,7 @@ namespace TensorFlowNET.UnitTest.layers_test
         {
             var sess = tf.Session().as_default();
 
-            var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(None, 4, 3, 1, 2));
+            var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(Unknown, 4, 3, 1, 2));
             sess.run(tf.layers.flatten(input), (input, np.arange(3 * 4 * 3 * 1 * 2).reshape(3, 4, 3, 1, 2))).Should().BeShaped(3, 24);
         }
     }

--- a/test/TensorFlowNET.UnitTest/layers_test/flatten.cs
+++ b/test/TensorFlowNET.UnitTest/layers_test/flatten.cs
@@ -36,5 +36,14 @@ namespace TensorFlowNET.UnitTest.layers_test
             var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape());
             new Action(() => sess.run(tf.layers.flatten(input), (input, NDArray.Scalar(6)))).Should().Throw<ValueError>();
         }
+
+        [TestMethod]
+        public void Case4()
+        {
+            var sess = tf.Session().as_default();
+
+            var input = tf.placeholder(TF_DataType.TF_INT32, new TensorShape(3, 4, None, 1, 2));
+            sess.run(tf.layers.flatten(input), (input, np.arange(3 * 4 * 3 * 1 * 2).reshape(3, 4, 3, 1, 2))).Should().BeShaped(3, 24);
+        }
     }
 }


### PR DESCRIPTION
I've decided to make Binding.None to be null - only seems logical to follow python's logic in this case.

Example for use case:
``` C#
var sess = tf.Session().as_default();

var input = tf.placeholder(tf.float64, shape: new TensorShape(None, 3, 3));
//or: var input = tf.placeholder(tf.float64, shape: new []{None, 3, 3});
var op = input[3];
sess.run(tf.global_variables_initializer());

var input_data = np.arange(5 * 3 * 3).reshape((5, 3, 3));
var ret = sess.run(op, (input, input_data));
```

This fixed #377 