### PR TITLE
Using ByteString instead of String

### DIFF
--- a/src/TensorFlowNET.Core/Sessions/BaseSession.cs
+++ b/src/TensorFlowNET.Core/Sessions/BaseSession.cs
@@ -279,7 +279,7 @@ namespace Tensorflow
                             break;
                         case TF_DataType.TF_STRING:
                             using (var reader = new CodedInputStream(new IntPtr(srcAddress).Stream(8, (long) tensor.bytesize)))
-                                ret = NDArray.FromString(reader.ReadString());
+                            	ret = new NDArray(reader.ReadBytes().ToByteArray());
                             break;
                         case TF_DataType.TF_UINT8:
                             ret = NDArray.Scalar(*(byte*) srcAddress);


### PR DESCRIPTION
In TF ByteString is more of a byte buffer than valid utf8. Reading it as a String adds escape characters to non-valid utf8. Then converting it to utf16 causes separate issues. Going from ByteString to byte[] fixes both of these.