### PR TITLE
fix NullReferenceException on session run

### DIFF
--- a/src/TensorFlowNET.Core/Sessions/BaseSession.cs
+++ b/src/TensorFlowNET.Core/Sessions/BaseSession.cs
@@ -65,7 +65,8 @@ namespace Tensorflow
 
         public virtual NDArray run(ITensorOrOperation fetche, params FeedItem[] feed_dict)
         {
-            return _run(fetche, feed_dict)[0];
+            var results = _run(fetche, feed_dict);
+            return fetche is Tensor ? results[0] : null;
         }
 
         public virtual (NDArray, NDArray, NDArray, NDArray, NDArray) run(

--- a/test/TensorFlowNET.UnitTest/SessionTest.cs
+++ b/test/TensorFlowNET.UnitTest/SessionTest.cs
@@ -132,6 +132,17 @@ namespace TensorFlowNET.UnitTest
                 }
             }
         }
+        
+        [TestMethod]
+        public void Autocast_Case0()
+        {
+            var sess = tf.Session().as_default();
+            ITensorOrOperation operation = tf.global_variables_initializer();
+            // the cast to ITensorOrOperation is essential for the test of this method signature
+            var ret = sess.run(operation);
+
+            ret.Should().BeNull();
+        }        
 
         [TestMethod]
         public void Autocast_Case1()


### PR DESCRIPTION
fix NullReferenceException on session run with ITensorOrOperation signature.
Unfortunately I'm not able to run unit tests on my machine.
(I'm missing the native lib on mac and I don't have time to build it from source).
I hope that somebody on core team could help to validate this fix.