### PR TITLE
Suppress active warnings

### DIFF
--- a/src/TensorFlowNET.Core/Eager/EagerRunner.RecordGradient.cs
+++ b/src/TensorFlowNET.Core/Eager/EagerRunner.RecordGradient.cs
@@ -43,7 +43,9 @@ namespace Tensorflow.Eager
             if (!should_record) return should_record;
 
             Tensor[] op_outputs;
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             bool op_outputs_tuple_created = false;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
             var unused_output_indices = gradient_exclustions.OpGradientUnusedOutputIndices(op_name);
             if (unused_output_indices != null)
             {
@@ -59,7 +61,9 @@ namespace Tensorflow.Eager
                 op_outputs = results;
 
             Tensor[] op_inputs;
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             bool op_inputs_tuple_created = false;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
             var unused_input_indices = gradient_exclustions.OpGradientUnusedInputIndices(op_name);
             if(unused_input_indices != null)
             {

--- a/src/TensorFlowNET.Core/Eager/EagerRunner.TFE_FastPathExecute.cs
+++ b/src/TensorFlowNET.Core/Eager/EagerRunner.TFE_FastPathExecute.cs
@@ -272,16 +272,22 @@ namespace Tensorflow.Eager
             if(attr_value == null)
             {
                 if (is_list != 0)
+#pragma warning disable CS0642 // Possible mistaken empty statement
                     ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
                 //SetOpAttrListDefault
                 else
+#pragma warning disable CS0642 // Possible mistaken empty statement
                     ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
                 //SetOpAttrScalarDefault
             }
             else
             {
                 if (is_list != 0)
+#pragma warning disable CS0642 // Possible mistaken empty statement
                     ;//  SetOpAttrList
+#pragma warning restore CS0642 // Possible mistaken empty statement
                 else
                     SetOpAttrScalar(ctx, op, attr_name, attr_value, type, attr_list_sizes, status);
             }

--- a/src/TensorFlowNET.Core/Framework/importer.cs
+++ b/src/TensorFlowNET.Core/Framework/importer.cs
@@ -83,7 +83,9 @@ namespace Tensorflow
 
             var combined_return_elements = new List<ITensorOrOperation>();
             int outputs_idx = 0;
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             int opers_idx = 0;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
             foreach(var name in requested_return_elements)
             {
                 if (name.Contains(":"))

--- a/src/TensorFlowNET.Core/Functions/Function.cs
+++ b/src/TensorFlowNET.Core/Functions/Function.cs
@@ -4,7 +4,9 @@ namespace Tensorflow
 {
     public class Function
     {
+#pragma warning disable CS0169 // The field 'Function._handle' is never used
         private IntPtr _handle;
+#pragma warning restore CS0169 // The field 'Function._handle' is never used
 
         public Function()
         {

--- a/src/TensorFlowNET.Core/Gradients/gradients_util.cs
+++ b/src/TensorFlowNET.Core/Gradients/gradients_util.cs
@@ -393,7 +393,9 @@ namespace Tensorflow
                 // Aggregate multiple gradients, and convert [] to None.
                 if (out_grad.Count > 0)
                 {
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
                     string used = "";
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
                     if (out_grad.Count < 2)
                     {
                         used = "nop";

--- a/src/TensorFlowNET.Core/Gradients/math_grad.cs
+++ b/src/TensorFlowNET.Core/Gradients/math_grad.cs
@@ -341,7 +341,9 @@ namespace Tensorflow.Gradients
                 var output_shape_tensor = array_ops.shape(op.outputs[0]);
                 var factor = _safe_shape_div(math_ops.reduce_prod(input_shape_tensor), math_ops.reduce_prod(output_shape_tensor));
                 throw new NotImplementedException("");
+#pragma warning disable CS0162 // Unreachable code detected
                 factor_tensor = null;
+#pragma warning restore CS0162 // Unreachable code detected
             }
 
             result = math_ops.truediv(sum_grad, math_ops.cast(factor_tensor, sum_grad.dtype));

--- a/src/TensorFlowNET.Core/Keras/Engine/Model.cs
+++ b/src/TensorFlowNET.Core/Keras/Engine/Model.cs
@@ -4,7 +4,9 @@ namespace Tensorflow.Keras.Engine
 {
     public class Model : Network
     {
+#pragma warning disable CS0169 // The field 'Model._cloning' is never used
         bool _cloning;
+#pragma warning restore CS0169 // The field 'Model._cloning' is never used
 #pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         bool _is_compiled;
 #pragma warning restore CS0108 // Member hides inherited member; missing new keyword

--- a/src/TensorFlowNET.Core/Keras/Engine/Model.cs
+++ b/src/TensorFlowNET.Core/Keras/Engine/Model.cs
@@ -8,7 +8,9 @@ namespace Tensorflow.Keras.Engine
         bool _cloning;
 #pragma warning restore CS0169 // The field 'Model._cloning' is never used
 #pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+#pragma warning disable CS0414 // The field 'Model._is_compiled' is assigned but its value is never used
         bool _is_compiled;
+#pragma warning restore CS0414 // The field 'Model._is_compiled' is assigned but its value is never used
 #pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         string loss;
         IOptimizer optimizer;

--- a/src/TensorFlowNET.Core/Keras/Engine/Model.cs
+++ b/src/TensorFlowNET.Core/Keras/Engine/Model.cs
@@ -5,7 +5,9 @@ namespace Tensorflow.Keras.Engine
     public class Model : Network
     {
         bool _cloning;
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         bool _is_compiled;
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         string loss;
         IOptimizer optimizer;
 

--- a/src/TensorFlowNET.Core/Keras/Engine/Sequential.cs
+++ b/src/TensorFlowNET.Core/Keras/Engine/Sequential.cs
@@ -20,7 +20,9 @@ namespace Tensorflow.Keras.Engine
 {
     public class Sequential : Model, ITensorFlowObject
     {
+#pragma warning disable CS0649 // Field 'Sequential._is_graph_network' is never assigned to, and will always have its default value false
         bool _is_graph_network;
+#pragma warning restore CS0649 // Field 'Sequential._is_graph_network' is never assigned to, and will always have its default value false
 #pragma warning disable CS0169 // The field 'Sequential.outputs' is never used
         Tensor[] outputs;
 #pragma warning restore CS0169 // The field 'Sequential.outputs' is never used

--- a/src/TensorFlowNET.Core/Keras/Engine/Sequential.cs
+++ b/src/TensorFlowNET.Core/Keras/Engine/Sequential.cs
@@ -21,7 +21,9 @@ namespace Tensorflow.Keras.Engine
     public class Sequential : Model, ITensorFlowObject
     {
         bool _is_graph_network;
+#pragma warning disable CS0169 // The field 'Sequential.outputs' is never used
         Tensor[] outputs;
+#pragma warning restore CS0169 // The field 'Sequential.outputs' is never used
 
         public Sequential(string name = null) 
             : base(name: name)

--- a/src/TensorFlowNET.Core/Keras/Layers/BatchNormalization.cs
+++ b/src/TensorFlowNET.Core/Keras/Layers/BatchNormalization.cs
@@ -23,14 +23,18 @@ namespace Tensorflow.Keras.Layers
 {
     public class BatchNormalization : Tensorflow.Layers.Layer
     {
+#pragma warning disable CS0414 // The field 'BatchNormalization._USE_V2_BEHAVIOR' is assigned but its value is never used
         private bool _USE_V2_BEHAVIOR = true;
+#pragma warning restore CS0414 // The field 'BatchNormalization._USE_V2_BEHAVIOR' is assigned but its value is never used
         private float momentum;
         private float epsilon;
         private bool center;
         private bool scale;
         private bool renorm;
         private bool fused;
+#pragma warning disable CS0414 // The field 'BatchNormalization._bessels_correction_test_only' is assigned but its value is never used
         private bool _bessels_correction_test_only;
+#pragma warning restore CS0414 // The field 'BatchNormalization._bessels_correction_test_only' is assigned but its value is never used
         private int[] axis;
         private string _data_format;
         private IInitializer beta_initializer;

--- a/src/TensorFlowNET.Core/Keras/Layers/Layer.cs
+++ b/src/TensorFlowNET.Core/Keras/Layers/Layer.cs
@@ -63,7 +63,9 @@ namespace Tensorflow.Keras.Layers
         private List<Node> _inbound_nodes;
         public List<Node> inbound_nodes => _inbound_nodes;
 
+#pragma warning disable CS0649 // Field 'Layer._outbound_nodes' is never assigned to, and will always have its default value null
         private List<Node> _outbound_nodes;
+#pragma warning restore CS0649 // Field 'Layer._outbound_nodes' is never assigned to, and will always have its default value null
         public List<Node> outbound_nodes => _outbound_nodes;
 
 #pragma warning disable CS0169 // The field 'Layer._initial_weights' is never used

--- a/src/TensorFlowNET.Core/Keras/Layers/Layer.cs
+++ b/src/TensorFlowNET.Core/Keras/Layers/Layer.cs
@@ -66,7 +66,9 @@ namespace Tensorflow.Keras.Layers
         private List<Node> _outbound_nodes;
         public List<Node> outbound_nodes => _outbound_nodes;
 
+#pragma warning disable CS0169 // The field 'Layer._initial_weights' is never used
         float _initial_weights;
+#pragma warning restore CS0169 // The field 'Layer._initial_weights' is never used
 
         public Layer(bool trainable = true, 
             string name = null, 

--- a/src/TensorFlowNET.Core/Keras/Layers/Pooling2D.cs
+++ b/src/TensorFlowNET.Core/Keras/Layers/Pooling2D.cs
@@ -26,7 +26,9 @@ namespace Tensorflow.Keras.Layers
         private int[] strides;
         private string padding;
         private string data_format;
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         private InputSpec input_spec;
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
 
         public Pooling2D(IPoolFunction pool_function,
             int[] pool_size,

--- a/src/TensorFlowNET.Core/Keras/Optimizers/SGD.cs
+++ b/src/TensorFlowNET.Core/Keras/Optimizers/SGD.cs
@@ -24,7 +24,9 @@ namespace Tensorflow.Keras.Optimizers
 
             _set_hyper("momentum", momentum);
 
+#pragma warning disable CS1717 // Assignment made to same variable
             nesterov = nesterov;
+#pragma warning restore CS1717 // Assignment made to same variable
         }
 
         protected override void _prepare_local(DeviceDType device_dtype, 

--- a/src/TensorFlowNET.Core/Keras/Optimizers/SGD.cs
+++ b/src/TensorFlowNET.Core/Keras/Optimizers/SGD.cs
@@ -10,7 +10,9 @@ namespace Tensorflow.Keras.Optimizers
     {
         protected override string _name => "SGD";
         
+#pragma warning disable CS0169 // The field 'SGD.nesterov' is never used
         bool nesterov;
+#pragma warning restore CS0169 // The field 'SGD.nesterov' is never used
 
         public SGD(float learning_rate, 
             float momentum = 0.0f,

--- a/src/TensorFlowNET.Core/Keras/Sequence.cs
+++ b/src/TensorFlowNET.Core/Keras/Sequence.cs
@@ -50,7 +50,9 @@ namespace Tensorflow.Keras
                 value = 0f;
 
             var nd = new NDArray(np.int32, new Shape(sequences.size, maxlen.Value));
+#pragma warning disable CS0162 // Unreachable code detected
             for (int i = 0; i < nd.shape[0]; i++)
+#pragma warning restore CS0162 // Unreachable code detected
             {
                 switch(sequences[i])
                 {

--- a/src/TensorFlowNET.Core/Keras/Utils/base_layer_utils.cs
+++ b/src/TensorFlowNET.Core/Keras/Utils/base_layer_utils.cs
@@ -38,8 +38,10 @@ namespace Tensorflow.Keras.Utils
             IInitializer initializer = null,
             bool trainable = true)
         {
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             var initializing_from_value = false;
             bool use_resource = true;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
 
             ops.init_scope();
 

--- a/src/TensorFlowNET.Core/Operations/ControlFlows/CondContext.cs
+++ b/src/TensorFlowNET.Core/Operations/ControlFlows/CondContext.cs
@@ -27,7 +27,9 @@ namespace Tensorflow.Operations
     /// </summary>
     public class CondContext : ControlFlowContext, IProtoBuf<CondContextDef, CondContext>
     {
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         private Dictionary<string, Tensor> _external_values = new Dictionary<string, Tensor>();
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
 
         /// <summary>
         /// 

--- a/src/TensorFlowNET.Core/Operations/ControlFlows/WhileContext.cs
+++ b/src/TensorFlowNET.Core/Operations/ControlFlows/WhileContext.cs
@@ -666,7 +666,9 @@ namespace Tensorflow.Operations
             return ret;
         }
 
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         public object to_proto()
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         {
             throw new NotImplementedException();
         }

--- a/src/TensorFlowNET.Core/Operations/Distributions/distribution.py.cs
+++ b/src/TensorFlowNET.Core/Operations/Distributions/distribution.py.cs
@@ -64,12 +64,16 @@ namespace Tensorflow
                 {
                     return _log_prob(value);
                 }
+#pragma warning disable CS0168 // Variable is declared but never used
                 catch (Exception e1)
+#pragma warning restore CS0168 // Variable is declared but never used
                 {
                     try
                     {
                         return math_ops.log(_prob(value));
+#pragma warning disable CS0168 // Variable is declared but never used
                     } catch (Exception e2)
+#pragma warning restore CS0168 // Variable is declared but never used
                     {
                         throw new NotImplementedException();
                     }

--- a/src/TensorFlowNET.Core/Operations/Initializers/GlorotUniform.cs
+++ b/src/TensorFlowNET.Core/Operations/Initializers/GlorotUniform.cs
@@ -31,7 +31,9 @@ namespace Tensorflow.Operations.Initializers
 
         }
 
+#pragma warning disable CS0114 // Member hides inherited member; missing override keyword
         public object get_config()
+#pragma warning restore CS0114 // Member hides inherited member; missing override keyword
         {
             return new
             {

--- a/src/TensorFlowNET.Core/Operations/Initializers/RandomUniform.cs
+++ b/src/TensorFlowNET.Core/Operations/Initializers/RandomUniform.cs
@@ -18,10 +18,18 @@ namespace Tensorflow.Operations.Initializers
 {
     public class RandomUniform : IInitializer
     {
+#pragma warning disable CS0649 // Field 'RandomUniform.seed' is never assigned to, and will always have its default value
         private int? seed;
+#pragma warning restore CS0649 // Field 'RandomUniform.seed' is never assigned to, and will always have its default value
+#pragma warning disable CS0649 // Field 'RandomUniform.minval' is never assigned to, and will always have its default value 0
         private float minval;
+#pragma warning restore CS0649 // Field 'RandomUniform.minval' is never assigned to, and will always have its default value 0
+#pragma warning disable CS0649 // Field 'RandomUniform.maxval' is never assigned to, and will always have its default value 0
         private float maxval;
+#pragma warning restore CS0649 // Field 'RandomUniform.maxval' is never assigned to, and will always have its default value 0
+#pragma warning disable CS0649 // Field 'RandomUniform.dtype' is never assigned to, and will always have its default value
         private TF_DataType dtype;
+#pragma warning restore CS0649 // Field 'RandomUniform.dtype' is never assigned to, and will always have its default value
 
         public RandomUniform()
         {

--- a/src/TensorFlowNET.Core/Operations/NnOps/_WithSpaceToBatch.cs
+++ b/src/TensorFlowNET.Core/Operations/NnOps/_WithSpaceToBatch.cs
@@ -34,7 +34,9 @@ namespace Tensorflow.Operations
             var dilation_rate_tensor = ops.convert_to_tensor(dilation_rate, TF_DataType.TF_INT32, name: "dilation_rate");
             var rate_shape = dilation_rate_tensor.TensorShape;
             var num_spatial_dims = rate_shape.dims[0];
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             int starting_spatial_dim = -1;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
             if (!string.IsNullOrEmpty(data_format) && data_format.StartsWith("NC"))
                 starting_spatial_dim = 2;
             else

--- a/src/TensorFlowNET.Core/Operations/OpDefLibrary.cs
+++ b/src/TensorFlowNET.Core/Operations/OpDefLibrary.cs
@@ -350,7 +350,9 @@ namespace Tensorflow
             if (attr_def.Type.StartsWith("list("))
             {
                 if (attr_def.HasMinimum)
+#pragma warning disable CS0642 // Possible mistaken empty statement
                     ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
                 attr_value.List = new AttrValue.Types.ListValue();
             }
 

--- a/src/TensorFlowNET.Core/Operations/Queues/PriorityQueue.cs
+++ b/src/TensorFlowNET.Core/Operations/Queues/PriorityQueue.cs
@@ -65,7 +65,9 @@ namespace Tensorflow.Queues
             });
         }
 
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         public Tensor[] dequeue(string name = null)
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         {
             Tensor[] ret;
             if (name == null)

--- a/src/TensorFlowNET.Core/Operations/_UserDeviceSpec.cs
+++ b/src/TensorFlowNET.Core/Operations/_UserDeviceSpec.cs
@@ -61,8 +61,12 @@ namespace Tensorflow
     {
         private StringOrFunction _device_name_or_function;
         private string display_name;
+#pragma warning disable CS0169 // The field '_UserDeviceSpec.function' is never used
         private FunctionDef function;
+#pragma warning restore CS0169 // The field '_UserDeviceSpec.function' is never used
+#pragma warning disable CS0169 // The field '_UserDeviceSpec.raw_string' is never used
         private string raw_string;
+#pragma warning restore CS0169 // The field '_UserDeviceSpec.raw_string' is never used
 
         public _UserDeviceSpec(StringOrFunction device_name_or_function)
         {

--- a/src/TensorFlowNET.Core/Operations/gen_array_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_array_ops.cs
@@ -19,7 +19,9 @@ using System.Collections.Generic;
 using static Tensorflow.Binding;
 using Tensorflow.Eager;
 using System.Linq;
+#pragma warning disable CS0105 // Using directive appeared previously in this namespace
 using static Tensorflow.Binding;
+#pragma warning restore CS0105 // Using directive appeared previously in this namespace
 
 namespace Tensorflow
 {

--- a/src/TensorFlowNET.Core/Operations/gen_control_flow_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_control_flow_ops.cs
@@ -152,7 +152,9 @@ namespace Tensorflow
         {
             var _op = tf._op_def_lib._apply_op_helper("Switch", name, new { data, pred });
             var _inputs_flat = _op.inputs;
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             var _attrs = ("T", _op.get_attr("T"));
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
             // TODO: missing original code
             //_execute.record_gradient("Switch", _inputs_flat, _attrs, _result, name);
             return new []{_op.outputs[0], _op.outputs[1]};

--- a/src/TensorFlowNET.Core/Operations/map_fn.cs
+++ b/src/TensorFlowNET.Core/Operations/map_fn.cs
@@ -10,7 +10,9 @@ using static Tensorflow.Binding;
 
 namespace Tensorflow
 {
+#pragma warning disable CS0659 // 'Operation' overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public partial class Operation
+#pragma warning restore CS0659 // 'Operation' overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         /// <summary>
         /// map on the list of tensors unpacked from `elems` on dimension 0.

--- a/src/TensorFlowNET.Core/Sessions/BaseSession.cs
+++ b/src/TensorFlowNET.Core/Sessions/BaseSession.cs
@@ -422,7 +422,9 @@ namespace Tensorflow
                         {
                             throw new NotImplementedException();
                             //TODO:! This is not the way to handle string[], it should be done with TF_DecodeString
+#pragma warning disable CS0162 // Unreachable code detected
                             using (var reader = new CodedInputStream(new IntPtr(srcAddress).Stream(8, (long) tensor.bytesize)))
+#pragma warning restore CS0162 // Unreachable code detected
                                 ret = NDArray.FromString(reader.ReadString());
                             break;
                         }

--- a/src/TensorFlowNET.Core/Summaries/EventFileWriter.cs
+++ b/src/TensorFlowNET.Core/Summaries/EventFileWriter.cs
@@ -31,7 +31,9 @@ namespace Tensorflow.Summaries
         EventsWriter _ev_writer;
         int _flush_secs;
         Event _sentinel_event;
+#pragma warning disable CS0414 // The field 'EventFileWriter._closed' is assigned but its value is never used
         bool _closed;
+#pragma warning restore CS0414 // The field 'EventFileWriter._closed' is assigned but its value is never used
         EventLoggerThread _worker;
 
         public EventFileWriter(string logdir, int max_queue = 10, int flush_secs= 120,

--- a/src/TensorFlowNET.Core/Summaries/EventLoggerThread.cs
+++ b/src/TensorFlowNET.Core/Summaries/EventLoggerThread.cs
@@ -27,7 +27,9 @@ namespace Tensorflow.Summaries
     public class EventLoggerThread
     {
         Queue<Event> _queue;
+#pragma warning disable CS0414 // The field 'EventLoggerThread.daemon' is assigned but its value is never used
         bool daemon;
+#pragma warning restore CS0414 // The field 'EventLoggerThread.daemon' is assigned but its value is never used
         EventsWriter _ev_writer;
         int _flush_secs;
         Event _sentinel_event;

--- a/src/TensorFlowNET.Core/Tensors/tensor_util.cs
+++ b/src/TensorFlowNET.Core/Tensors/tensor_util.cs
@@ -71,9 +71,13 @@ namespace Tensorflow
                 return np.frombuffer(tensor.TensorContent.ToByteArray(), tensor_dtype).reshape(shape);
             }
             else if (tensor.Dtype == DataType.DtHalf || tensor.Dtype == DataType.DtBfloat16)
+#pragma warning disable CS0642 // Possible mistaken empty statement
                 ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
             else if (tensor.Dtype == DataType.DtFloat)
+#pragma warning disable CS0642 // Possible mistaken empty statement
                 ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
             else if (new DataType[] { DataType.DtInt32, DataType.DtUint8 }.Contains(tensor.Dtype))
             {
                 if (tensor.IntVal.Count == 1)

--- a/src/TensorFlowNET.Core/Training/Optimizer.cs
+++ b/src/TensorFlowNET.Core/Training/Optimizer.cs
@@ -374,7 +374,9 @@ namespace Tensorflow
         {
             // Scale loss if using a "mean" loss reduction and multiple replicas.
             loss = _scale_loss(loss);
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             int num_towers = 1;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
 
             if(var_list == null)
             {

--- a/src/TensorFlowNET.Core/Training/Saving/Saver.cs
+++ b/src/TensorFlowNET.Core/Training/Saving/Saver.cs
@@ -241,7 +241,9 @@ namespace Tensorflow
             Console.WriteLine($"Restoring parameters from {save_path}");
 
             if (tf.context.executing_eagerly())
+#pragma warning disable CS0642 // Possible mistaken empty statement
                 ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
             else
                 sess.run(_saver_def.RestoreOpName,
                     new FeedItem(_saver_def.FilenameTensorName, save_path));

--- a/src/TensorFlowNET.Core/Training/Saving/Saver.cs
+++ b/src/TensorFlowNET.Core/Training/Saving/Saver.cs
@@ -42,7 +42,9 @@ namespace Tensorflow
         private bool _is_built;
         private SaverDef.Types.CheckpointFormatVersion _write_version;
         private bool _pad_step_number;
+#pragma warning disable CS0649 // Field 'Saver._filename' is never assigned to, and will always have its default value null
         private string _filename;
+#pragma warning restore CS0649 // Field 'Saver._filename' is never assigned to, and will always have its default value null
         private bool _is_empty;
         private float _next_checkpoint_time;
         private bool _save_relative_paths;

--- a/src/TensorFlowNET.Core/Training/Saving/Saver.cs
+++ b/src/TensorFlowNET.Core/Training/Saving/Saver.cs
@@ -46,7 +46,9 @@ namespace Tensorflow
         private bool _is_empty;
         private float _next_checkpoint_time;
         private bool _save_relative_paths;
+#pragma warning disable CS0414 // The field 'Saver._object_restore_saver' is assigned but its value is never used
         private bool? _object_restore_saver;
+#pragma warning restore CS0414 // The field 'Saver._object_restore_saver' is assigned but its value is never used
         private Dictionary<string, float> _last_checkpoints;
         private Dictionary<string, float> _checkpoints_to_be_deleted;
 

--- a/src/TensorFlowNET.Core/Training/SecondOrStepTimer.cs
+++ b/src/TensorFlowNET.Core/Training/SecondOrStepTimer.cs
@@ -11,7 +11,9 @@ namespace Tensorflow.Training
         int _every_secs = 60;
         int _every_steps = 0;
         int _last_triggered_step = 0;
+#pragma warning disable CS0414 // The field 'SecondOrStepTimer._last_triggered_time' is assigned but its value is never used
         int _last_triggered_time = 0;
+#pragma warning restore CS0414 // The field 'SecondOrStepTimer._last_triggered_time' is assigned but its value is never used
 
         public SecondOrStepTimer(int every_secs, int every_steps)
         {

--- a/src/TensorFlowNET.Core/Training/Trackable.cs
+++ b/src/TensorFlowNET.Core/Training/Trackable.cs
@@ -39,7 +39,9 @@ namespace Tensorflow.Train
             VariableAggregation aggregation = VariableAggregation.None)
         {
             ops.init_scope();
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
             IInitializer checkpoint_initializer = null;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
             if (tf.context.executing_eagerly())
                 ;
             else

--- a/src/TensorFlowNET.Core/Training/Trackable.cs
+++ b/src/TensorFlowNET.Core/Training/Trackable.cs
@@ -43,7 +43,9 @@ namespace Tensorflow.Train
             IInitializer checkpoint_initializer = null;
 #pragma warning restore CS0219 // Variable is assigned but its value is never used
             if (tf.context.executing_eagerly())
+#pragma warning disable CS0642 // Possible mistaken empty statement
                 ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
             else
                 checkpoint_initializer = null;
 

--- a/src/TensorFlowNET.Core/Variables/RefVariable.cs
+++ b/src/TensorFlowNET.Core/Variables/RefVariable.cs
@@ -116,7 +116,9 @@ namespace Tensorflow
             if (variable_def.SaveSliceInfoDef != null)
                 throw new NotImplementedException("save_slice_info_def");
             else
+#pragma warning disable CS0642 // Possible mistaken empty statement
                 ;// _save_slice_info = null;
+#pragma warning restore CS0642 // Possible mistaken empty statement
 
             //_caching_device = null;
             //_constraint = null;

--- a/src/TensorFlowNET.Core/Variables/ResourceVariable.cs
+++ b/src/TensorFlowNET.Core/Variables/ResourceVariable.cs
@@ -30,7 +30,9 @@ namespace Tensorflow
     {
         Tensor _cached_value;
         public string Device => handle.Device;
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         public Graph Graph => handle.graph;
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         public Operation op => handle.op;
         public Tensor is_initialized_op { get; set; }
 

--- a/src/TensorFlowNET.Core/Variables/VariableScope.cs
+++ b/src/TensorFlowNET.Core/Variables/VariableScope.cs
@@ -25,7 +25,9 @@ namespace Tensorflow
     public class VariableScope
     {
         public bool use_resource { get; set; }
+#pragma warning disable CS0414 // The field 'VariableScope._reuse' is assigned but its value is never used
         private _ReuseMode _reuse;
+#pragma warning restore CS0414 // The field 'VariableScope._reuse' is assigned but its value is never used
         public bool resue;
 
         private TF_DataType _dtype;

--- a/src/TensorFlowNET.Core/Variables/_VariableStore.cs
+++ b/src/TensorFlowNET.Core/Variables/_VariableStore.cs
@@ -27,7 +27,9 @@ namespace Tensorflow
     {
         private Dictionary<string, object> _vars;
         private Dictionary<string, object> _partitioned_vars;
+#pragma warning disable CS0414 // The field '_VariableStore._store_eager_variables' is assigned but its value is never used
         private bool _store_eager_variables;
+#pragma warning restore CS0414 // The field '_VariableStore._store_eager_variables' is assigned but its value is never used
 
         public _VariableStore()
         {

--- a/src/TensorFlowNET.Core/ops._DefaultStack.cs
+++ b/src/TensorFlowNET.Core/ops._DefaultStack.cs
@@ -26,7 +26,9 @@ namespace Tensorflow
         public class _DefaultStack : ITensorFlowObject
         {
             Stack<object> stack;
+#pragma warning disable CS0414 // The field 'ops._DefaultStack._enforce_nesting' is assigned but its value is never used
             bool _enforce_nesting = true;
+#pragma warning restore CS0414 // The field 'ops._DefaultStack._enforce_nesting' is assigned but its value is never used
 
             public _DefaultStack()
             {

--- a/src/TensorFlowNET.Keras/Layers/Core/Dense.cs
+++ b/src/TensorFlowNET.Keras/Layers/Core/Dense.cs
@@ -28,7 +28,9 @@ namespace Keras.Layers
         RefVariable W;
         int units;
         TensorShape WShape;
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         string name;
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         IActivation activation;
 
         public Dense(int units, string name = null, IActivation activation = null)
@@ -60,7 +62,9 @@ namespace Keras.Layers
         {
             return WShape;
         }
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
         public TensorShape output_shape(TensorShape input_shape)
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
         {
             var output_shape = input_shape.dims;
             output_shape[output_shape.Length - 1] = units;

--- a/src/TensorFlowNET.Keras/Model.cs
+++ b/src/TensorFlowNET.Keras/Model.cs
@@ -50,7 +50,9 @@ namespace Tensorflow.Keras
             {
                 return Flow;
             }
+#pragma warning disable CS0168 // Variable is declared but never used
             catch (Exception ex)
+#pragma warning restore CS0168 // Variable is declared but never used
             {
                 return null;
             }

--- a/src/TensorFlowNet.Benchmarks/Program.cs
+++ b/src/TensorFlowNet.Benchmarks/Program.cs
@@ -20,7 +20,9 @@ namespace TensorFlowBenchmark
             }
             else
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, ManualConfig.Create(DefaultConfig.Instance).With(ConfigOptions.DisableOptimizationsValidator));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             Console.ReadLine();

--- a/test/TensorFlowNET.UnitTest/MultithreadingTests.cs
+++ b/test/TensorFlowNET.UnitTest/MultithreadingTests.cs
@@ -167,7 +167,9 @@ namespace TensorFlowNET.UnitTest
             {
                 using (var sess = tf.Session())
                 {
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
                     Tensor t = null;
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
                     for (int i = 0; i < 100; i++)
                     {
                         var v = (int*) Marshal.AllocHGlobal(sizeof(int));

--- a/test/TensorFlowNET.UnitTest/Utilities/PrivateObject.cs
+++ b/test/TensorFlowNET.UnitTest/Utilities/PrivateObject.cs
@@ -20,7 +20,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         // bind everything
         private const BindingFlags BindToEveryThing = BindingFlags.Default | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public;
 
+#pragma warning disable CS0414 // The field 'PrivateObject.constructorFlags' is assigned but its value is never used
         private static BindingFlags constructorFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance | BindingFlags.NonPublic;
+#pragma warning restore CS0414 // The field 'PrivateObject.constructorFlags' is assigned but its value is never used
 
         private object target; // automatically initialized to null
         private Type originalType; // automatically initialized to null


### PR DESCRIPTION
Suppress warnings currently appearing in the build.

Eventually these should be fixed, but I didn't want to make the determination for each case at this point. If there is any specific diagnostic ID you would like to see _fixed_ (as opposed to suppressed), let me know and I can make that change.