### PR TITLE
port constant_value_as_shape & some of its deps

### DIFF
--- a/src/TensorFlowNET.Core/Graphs/Graph.cs
+++ b/src/TensorFlowNET.Core/Graphs/Graph.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.InteropServices;
 using static Tensorflow.Binding;

--- a/src/TensorFlowNET.Core/Graphs/Graph.cs
+++ b/src/TensorFlowNET.Core/Graphs/Graph.cs
@@ -560,5 +560,23 @@ namespace Tensorflow
         {
             return graph._handle;
         }
+        
+        public OrderedDictionary _captures => new OrderedDictionary();
+
+        public Tensor[] external_captures()
+        {
+            Tensor[] captures = new Tensor[this._captures.Count];
+            ICollection inner = this._captures.Keys; // c[0]
+            inner.CopyTo(captures, 0);
+            return captures;
+        }
+        
+        public Tensor[] internal_captures()
+        {
+            Tensor[] captures = new Tensor[this._captures.Count];
+            ICollection inner = this._captures.Values; // c[1]
+            inner.CopyTo(captures, 0);
+            return captures;
+        }
     }
 }


### PR DESCRIPTION
This PR (hopefully; I haven't tested the function other than it not throwing errors at build) implements: 

- `tensor_util.constant_value_as_shape`
- `graph._captures`
- `graph.external_captures`
- `graph.internal_captures`

It's my first PR here, and first time working with C# for more than toy purposes, so don't kill me if something here doesn't work like it should. 👍