### PR TITLE
add GradientOperatorMulTest 。

### DIFF
--- a/test/TensorFlowNET.UnitTest/ManagedAPI/GradientTest.cs
+++ b/test/TensorFlowNET.UnitTest/ManagedAPI/GradientTest.cs
@@ -35,5 +35,17 @@ namespace TensorFlowNET.UnitTest.ManagedAPI
             var y_grad = tape.gradient(y, x);
             Assert.AreEqual(9.0, (double)y);
         }
+
+        [TestMethod]
+        public void GradientOperatorMulTest()
+        {
+            var x = tf.constant(0f);
+            var w = tf.Variable(new float[] { 1, 1 });
+            using var gt = tf.GradientTape();
+            var y = x * w;
+            var gr = gt.gradient(y, w);
+            Assert.AreNotEqual(null, gr);
+        }
+
     }
 }


### PR DESCRIPTION
当对于张量乘法算式进行求导时，
无论是变量是单个数，还是常量是单个数，而另一个又是一个数组时，
如果组成乘法的算式将常量放乘法左边，变量放乘法右边，
对这个算式进行求导时，会发生求导返回值为 null 的情况。