### PR TITLE
Array operations

### DIFF
--- a/src/TensorFlowNET.Core/APIs/tf.random.cs
+++ b/src/TensorFlowNET.Core/APIs/tf.random.cs
@@ -69,7 +69,17 @@ namespace Tensorflow
             float maxval = 1,
             TF_DataType dtype = TF_DataType.TF_FLOAT,
             int? seed = null,
-            string name = null) => random_ops.random_uniform(shape, minval, maxval, dtype, seed, name);
+            string name = null)
+        {
+            if (dtype.is_integer())
+            {
+                return random_ops.random_uniform_int(shape, (int)minval, (int)maxval, dtype, seed, name);
+            }
+            else
+            {
+                return random_ops.random_uniform(shape, minval, maxval, dtype, seed, name);
+            }
+        }
 
         public Tensor truncated_normal(TensorShape shape,
             float mean = 0.0f,

--- a/src/TensorFlowNET.Core/Operations/Initializers/RandomUniform.cs
+++ b/src/TensorFlowNET.Core/Operations/Initializers/RandomUniform.cs
@@ -18,20 +18,17 @@ namespace Tensorflow.Operations.Initializers
 {
     public class RandomUniform : IInitializer
     {
-#pragma warning disable CS0649 // Field 'RandomUniform.seed' is never assigned to, and will always have its default value
         private int? seed;
-#pragma warning restore CS0649 // Field 'RandomUniform.seed' is never assigned to, and will always have its default value
-#pragma warning disable CS0649 // Field 'RandomUniform.minval' is never assigned to, and will always have its default value 0
         private float minval;
-#pragma warning restore CS0649 // Field 'RandomUniform.minval' is never assigned to, and will always have its default value 0
-#pragma warning disable CS0649 // Field 'RandomUniform.maxval' is never assigned to, and will always have its default value 0
         private float maxval;
-#pragma warning restore CS0649 // Field 'RandomUniform.maxval' is never assigned to, and will always have its default value 0
         private TF_DataType dtype;
 
-        public RandomUniform(TF_DataType dtype = TF_DataType.TF_FLOAT)
+        public RandomUniform(TF_DataType dtype = TF_DataType.TF_FLOAT, float minval = -0.05f, float maxval = 0.05f, int? seed = null)
         {
             this.dtype = dtype;
+            this.minval = minval;
+            this.maxval = maxval;
+            this.seed = seed;
         }
 
         public Tensor Apply(InitializerArgs args)

--- a/src/TensorFlowNET.Core/Operations/array_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/array_ops.cs
@@ -843,7 +843,22 @@ namespace Tensorflow
             return gen_array_ops.concat_v2(values, axis, name: name);
         }
 
-        public static Tensor gather<T1, T2>(T1 @params, T2 indices, string name = null, int axis = 0)
+        /// <summary>
+        /// Gather slices from `params` according to `indices`. `indices` must be an integer tensor of any dimension(often 1-D).
+        /// </summary>
+        /// <typeparam name="T1">Element type of the indexed tensor.</typeparam>
+        /// <typeparam name="T2">Element type of the index tensor.</typeparam>
+        /// <param name="params">The `Tensor` from which to gather values. Must be at least rank `axis + 1`.</param>
+        /// <param name="indices">The index `Tensor`.  Must be one of the following types: `int32`, `int64`. The values must be in range `[0, params.shape[axis])`.</param>
+        /// <param name="name">A name for the operation (optional).</param>
+        /// <param name="axis">
+        /// A `Tensor`. Must be one of the following types: `int32`, `int64`. 
+        /// The `axis` in `params` to gather `indices` from.Must be greater than or equal to `batch_dims`.  
+        /// Defaults to the first non-batch dimension. Supports negative indexes.
+        /// </param>
+        /// <param name="batch_dims">An integer. The number of batch dimensions. Must be less than or equal to rank(indices).</param>
+        /// <returns></returns>
+        public static Tensor gather<T1, T2>(T1 @params, T2 indices, string name = null, int axis = 0, int batch_dims = 0)
         {
             if (axis != 0)
                 return gen_array_ops.gather_v2(@params, indices, axis, name: name);
@@ -913,7 +928,7 @@ namespace Tensorflow
         }
 
         public static Tensor slice(Tensor input, Tensor[] begin, Tensor[] size, string name = null)
-            => gen_array_ops.slice(input, begin, size, name: name);
+               => gen_array_ops.slice(input, begin, size, name: name);
 
         public static Tensor slice<Tb, Ts>(Tensor input, Tb begin, Ts size, string name = null)
             => gen_array_ops.slice(input, begin, size, name: name);
@@ -927,6 +942,7 @@ namespace Tensorflow
                     Index = op.get_attr<int>("Index")
                 }
             });
+
 
         public static Tensor stack(object values, int axis = 0, string name = "stack")
         {

--- a/src/TensorFlowNET.Core/Operations/gen_array_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_array_ops.cs
@@ -123,7 +123,7 @@ namespace Tensorflow
             {
                 try
                 {
-                    var results = tf.Runner.TFE_FastPathExecute(new FastPathOpExecInfo("GatherV2", name, @params, indices, axis, "batch_dims")
+                    var results = tf.Runner.TFE_FastPathExecute(new FastPathOpExecInfo("GatherV2", name, @params, indices, axis, "batch_dims", 0)
                     {
                         ctx = tf.Context,
                         device_name = tf.Context.DeviceName

--- a/src/TensorFlowNET.Core/Operations/gen_random_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_random_ops.cs
@@ -43,18 +43,8 @@ namespace Tensorflow
         /// <param name="name"></param>
         /// <returns></returns>
         public static Tensor random_uniform_int(Tensor shape, Tensor minval, Tensor maxval, int? seed = 0, int? seed2 = 0, string name = null)
-        {
-            if (!seed.HasValue)
-                seed = 0;
-            if (!seed2.HasValue)
-                seed2 = 0;
-
-            var _op = tf.OpDefLib._apply_op_helper("RandomUniformInt",
-                name: name,
-                args: new { shape, minval, maxval, seed, seed2 });
-
-            return _op.outputs[0];
-        }
+         => tf.Context.ExecuteOp("RandomUniformInt", name, new ExecuteOpArgs(shape, minval, maxval)
+                .SetAttributes(new { seed = seed ?? 0, seed2 = seed2 ?? 0 }));
 
         /// <summary>
         /// Outputs random values from a uniform distribution.

--- a/src/TensorFlowNET.Core/Operations/random_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/random_ops.cs
@@ -81,6 +81,34 @@ namespace Tensorflow
             });
         }
 
+        /// <summary>
+        /// Outputs random values from a uniform distribution.
+        /// </summary>
+        /// <param name="shape"></param>
+        /// <param name="minval"></param>
+        /// <param name="maxval"></param>
+        /// <param name="dtype">The type of the output</param>
+        /// <param name="seed">Used to create a random seed for the distribution.</param>
+        /// <param name="name">A name for the operation</param>
+        /// <returns>A tensor of the specified shape filled with random uniform values.</returns>
+        public static Tensor random_uniform_int(int[] shape,
+            int minval = 0,
+            int maxval = 1,
+            TF_DataType dtype = TF_DataType.TF_FLOAT,
+            int? seed = null,
+            string name = null)
+        {
+            return tf_with(ops.name_scope(name, "random_uniform_int", new { shape, minval, maxval }), scope =>
+            {
+                name = scope;
+                var (seed1, seed2) = random_seed.get_seed(seed);
+                var tensorShape = tensor_util.shape_tensor(shape);
+                var minTensor = ops.convert_to_tensor(minval, dtype: dtype, name: "min");
+                var maxTensor = ops.convert_to_tensor(maxval, dtype: dtype, name: "max");
+                return gen_random_ops.random_uniform_int(tensorShape, minTensor, maxTensor, seed: seed1, seed2: seed2);
+            });
+        }
+
         public static Tensor random_uniform(Tensor shape,
             int minval = 0,
             Tensor maxval = null,

--- a/src/TensorFlowNET.Keras/Layers/Core/Embedding.cs
+++ b/src/TensorFlowNET.Keras/Layers/Core/Embedding.cs
@@ -48,7 +48,7 @@ namespace Tensorflow.Keras.Layers
             if (args.BatchInputShape == null)
                 args.BatchInputShape = new int[] { args.BatchSize }.Concat(args.InputShape.dims).ToArray();
 
-            embeddings_initializer = embeddings_initializer ?? tf.random_uniform_initializer;
+            embeddings_initializer = args.EmbeddingsInitializer ?? tf.random_uniform_initializer;
             SupportsMasking = mask_zero;
         }
 

--- a/test/TensorFlowNET.Keras.UnitTest/Layers/LayersTest.cs
+++ b/test/TensorFlowNET.Keras.UnitTest/Layers/LayersTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NumSharp;
 using Tensorflow;
+using Tensorflow.Operations.Initializers;
 using static Tensorflow.Binding;
 using static Tensorflow.KerasApi;
 
@@ -60,13 +61,26 @@ namespace TensorFlowNET.Keras.UnitTest
             Assert.AreEqual(model.Layers.Count, 8);
             var result = model.predict(tf.constant(np.arange(24).astype(np.float32)[np.newaxis, Slice.All]));
             Assert.AreEqual(result.shape, new TensorShape(1, 24));
-            model.fit(np.arange(24).astype(np.float32)[np.newaxis, Slice.All], np.arange(24).astype(np.float32)[np.newaxis, Slice.All], verbose: 0); 
+            model.fit(np.arange(24).astype(np.float32)[np.newaxis, Slice.All], np.arange(24).astype(np.float32)[np.newaxis, Slice.All], verbose: 0);
         }
 
         /// <summary>
         /// https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding
         /// </summary>
-        [TestMethod, Ignore]
+        [TestMethod]
+        public void Embedding_Simple()
+        {
+            var emb = keras.layers.Embedding(256, 12, input_length: 4);
+            var input_array = np.arange(12).reshape(3, 4).astype(np.float32);
+            var output = emb.Apply(input_array);
+            Assert.AreEqual(new TensorShape(3, 4, 12), output.shape);
+        }
+
+        /// <summary>
+        /// https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding
+        /// </summary>
+        [TestMethod]
+        [Ignore]
         public void Embedding()
         {
             var model = keras.Sequential();

--- a/test/TensorFlowNET.UnitTest/ManagedAPI/ArrayOpsTest.cs
+++ b/test/TensorFlowNET.UnitTest/ManagedAPI/ArrayOpsTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NumSharp;
+using NumSharp.Utilities;
 using Tensorflow;
 using static Tensorflow.Binding;
 
@@ -7,9 +8,48 @@ namespace TensorFlowNET.UnitTest.ManagedAPI
 {
     [TestClass]
     public class ArrayOpsTest : EagerModeTestBase
-    { 
+    {
         /// <summary>
-        /// https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding
+        /// https://www.tensorflow.org/api_docs/python/tf/slice
+        /// </summary>
+        [TestMethod]
+        public void Slice()
+        {
+            // Tests based on example code in TF documentation
+            var input_array = tf.constant(np.array(new int[] { 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6 }).reshape(3,2,3));
+            var indices = tf.constant(np.array(new int[] { 0, 2 }));
+
+            var r1 = array_ops.slice(input_array, new int[] { 1, 0, 0 }, new int[] { 1, 1, 3 });
+            Assert.AreEqual(new TensorShape(1,1,3), r1.shape);
+            var r1np = r1.numpy();
+            Assert.AreEqual(r1np[0, 0, 0], 3);
+            Assert.AreEqual(r1np[0, 0, 1], 3);
+            Assert.AreEqual(r1np[0, 0, 2], 3);
+
+
+            var r2 = array_ops.slice(input_array, new int[] { 1, 0, 0 }, new int[] { 1, 2, 3 });
+            Assert.AreEqual(new TensorShape(1, 2, 3), r2.shape);
+            var r2np = r2.numpy();
+            Assert.AreEqual(r2np[0, 0, 0], 3);
+            Assert.AreEqual(r2np[0, 0, 1], 3);
+            Assert.AreEqual(r2np[0, 0, 2], 3);
+            Assert.AreEqual(r2np[0, 1, 0], 4);
+            Assert.AreEqual(r2np[0, 1, 1], 4);
+            Assert.AreEqual(r2np[0, 1, 2], 4);
+
+            var r3 = array_ops.slice(input_array, new int[] { 1, 0, 0 }, new int[] { 2, 1, 3 });
+            Assert.AreEqual(new TensorShape(2, 1, 3), r3.shape);
+            var r3np = r3.numpy();
+            Assert.AreEqual(r3np[0, 0, 0], 3);
+            Assert.AreEqual(r3np[0, 0, 1], 3);
+            Assert.AreEqual(r3np[0, 0, 2], 3);
+            Assert.AreEqual(r3np[1, 0, 0], 5);
+            Assert.AreEqual(r3np[1, 0, 1], 5);
+            Assert.AreEqual(r3np[1, 0, 2], 5);
+        }
+
+        /// <summary>
+        /// https://www.tensorflow.org/api_docs/python/tf/gather
         /// </summary>
         [TestMethod]
         public void Gather()
@@ -19,9 +59,24 @@ namespace TensorFlowNET.UnitTest.ManagedAPI
 
             var result = array_ops.gather(input_array, indices);
             Assert.AreEqual(new TensorShape(2, 4), result.shape);
-            Assert.AreEqual(result.numpy()[0,0], 0.0f);
-            Assert.AreEqual(result.numpy()[0,1], 1.0f);
-            Assert.AreEqual(result.numpy()[1,3], 11.0f);
+            Assert.AreEqual(result.numpy()[0, 0], 0.0f);
+            Assert.AreEqual(result.numpy()[0, 1], 1.0f);
+            Assert.AreEqual(result.numpy()[1, 3], 11.0f);
+
+            // Tests based on example code in Python doc string for tf.gather()
+
+            var p1 = tf.random.normal(new TensorShape(5, 6, 7, 8));
+            var i1 = tf.random_uniform(new TensorShape(10, 11), maxval: 7, dtype: tf.int32);
+            var r1 = tf.gather(p1, i1, axis:2);
+            Assert.AreEqual(new TensorShape(5, 6, 10, 11, 8), r1.shape);
+
+            var p2 = tf.random.normal(new TensorShape(4,3));
+            var i2 = tf.constant(new int[,] { { 0, 2} });
+            var r2 = tf.gather(p2, i2, axis: 0);
+            Assert.AreEqual(new TensorShape(1, 2, 3), r2.shape);
+
+            var r3 = tf.gather(p2, i2, axis: 1);
+            Assert.AreEqual(new TensorShape(4,1,2), r3.shape);
         }
     }
 }

--- a/test/TensorFlowNET.UnitTest/ManagedAPI/ArrayOpsTest.cs
+++ b/test/TensorFlowNET.UnitTest/ManagedAPI/ArrayOpsTest.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NumSharp;
+using Tensorflow;
+using static Tensorflow.Binding;
+
+namespace TensorFlowNET.UnitTest.ManagedAPI
+{
+    [TestClass]
+    public class ArrayOpsTest : EagerModeTestBase
+    { 
+        /// <summary>
+        /// https://www.tensorflow.org/api_docs/python/tf/keras/layers/Embedding
+        /// </summary>
+        [TestMethod]
+        public void Gather()
+        {
+            var input_array = tf.constant(np.arange(12).reshape(3, 4).astype(np.float32));
+            var indices = tf.constant(np.array(new int[] { 0, 2 }));
+
+            var result = array_ops.gather(input_array, indices);
+            Assert.AreEqual(new TensorShape(2, 4), result.shape);
+            Assert.AreEqual(result.numpy()[0,0], 0.0f);
+            Assert.AreEqual(result.numpy()[0,1], 1.0f);
+            Assert.AreEqual(result.numpy()[1,3], 11.0f);
+        }
+    }
+}


### PR DESCRIPTION
I added unit tests for slice and gather, and fixed the eager-mode implementation of gather.
I also added the ability to generate integer tensors with tf.random_uniform(), which is available in Python.