### PR TITLE
Fix casting issue causing AccessViolationException

### DIFF
--- a/src/TensorFlowNET.Core/Tensors/Tensor.Creation.cs
+++ b/src/TensorFlowNET.Core/Tensors/Tensor.Creation.cs
@@ -531,7 +531,7 @@ namespace Tensorflow
                 dims: nd.shape.Select(i => (long)i).ToArray(),
                 num_dims: nd.ndim,
                 data: arraySlice.Address,
-                len: (ulong)(nd.size * nd.dtypesize));
+                len: (ulong)nd.size * (ulong)nd.dtypesize);
 
             // if TF decided not to perform copy, hold reference for given NDArray.
             if (TensorDataPointer.ToPointer() == arraySlice.Address)


### PR DESCRIPTION
This fixes the following bug:

- Create a numpy array that is 25,763 x 25,763
- Implicitly convert to a `Tensor` object
- An `AccessViolationException` is thrown

This is because the lengths of the arrays are not calculated properly - casting to a ulong occurs /after/ the multiplication. As such, it tries to read past the end of the array