### PR TITLE
Gen array ops bug fixes

### DIFF
--- a/src/TensorFlowNET.Core/Operations/gen_array_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_array_ops.cs
@@ -193,11 +193,8 @@ namespace Tensorflow
         }
 
         public static Tensor log(Tensor x, string name = null)
-        {
-            var _op = tf.OpDefLib._apply_op_helper("Log", name: name, args: new { x });
+            => tf.Context.ExecuteOp("Log", name, new ExecuteOpArgs(x));
 
-            return _op.outputs[0];
-        }
 
         public static Tensor rank(Tensor input, string name = null)
             => tf.Context.ExecuteOp("Rank", name, new ExecuteOpArgs(input));

--- a/src/TensorFlowNET.Core/Operations/gen_math_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_math_ops.cs
@@ -64,7 +64,8 @@ namespace Tensorflow
         /// <param name="name"></param>
         /// <returns></returns>
         public static Tensor arg_min(Tensor input, int dimension, TF_DataType output_type = TF_DataType.TF_INT64, string name = null)
-            => tf.OpDefLib._apply_op_helper("ArgMin", name, args: new { input, dimension, output_type }).outputs[0];
+            => tf.Context.ExecuteOp("ArgMin", name, new ExecuteOpArgs(input, dimension)
+                .SetAttributes(new { output_type }));
 
         /// <summary>
         /// Computes Psi, the derivative of Lgamma (the log of the absolute value of

--- a/src/TensorFlowNET.Core/Operations/gen_math_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/gen_math_ops.cs
@@ -476,8 +476,11 @@ namespace Tensorflow
             return _op.outputs[0];
         }
 
-        public static Tensor _max<Tx, Ty>(Tx input, Ty axis, bool keep_dims = false, string name = null)
-            => tf.Context.ExecuteOp("Max", name, new ExecuteOpArgs(input, axis)
+        /// <summary>
+        /// Subroutine for Min or Max functions. See _min and _max
+        /// </summary>
+        private static Tensor MinOrMax<Tx, Ty>(Tx input, Ty axis, string methodName, bool keep_dims = false, string name = null)
+            => tf.Context.ExecuteOp(methodName, name, new ExecuteOpArgs(input, axis)
             {
                 GetGradientAttrs = (op) => new
                 {
@@ -487,12 +490,12 @@ namespace Tensorflow
                 }
             }.SetAttributes(new { keep_dims, reduction_indices = axis }));
 
-        public static Tensor _min<Tx, Ty>(Tx input, Ty axis, bool keep_dims = false, string name = null)
-        {
-            var _op = tf.OpDefLib._apply_op_helper("Min", name, new { input, reduction_indices = axis, keep_dims });
+        public static Tensor _max<Tx, Ty>(Tx input, Ty axis, bool keep_dims = false, string name = null)
+            => MinOrMax(input, axis, "Max", keep_dims: keep_dims, name: name);
 
-            return _op.outputs[0];
-        }
+        public static Tensor _min<Tx, Ty>(Tx input, Ty axis, bool keep_dims = false, string name = null)
+            => MinOrMax(input, axis, "Min", keep_dims: keep_dims, name: name);
+
 
         public static Tensor pow<Tx, Ty>(Tx x, Ty y, string name = null)
             => tf.Context.ExecuteOp("Pow", name, new ExecuteOpArgs(x, y));


### PR DESCRIPTION
Hiya,

This follows up my previous merge request (#783) with more methods that crash with Attempting to capture an EagerTensor without building a function

fixed are `log`, `arg_min`, `_min`, `_max`

Cheers
