### PR TITLE
docs: fix links to examples

### DIFF
--- a/docs/source/LinearRegression.md
+++ b/docs/source/LinearRegression.md
@@ -82,4 +82,4 @@ When we visualize the graph in TensorBoard:
 
 ![linear-regression](_static/linear-regression-tensor-board.png)
 
-The full example is [here](https://github.com/SciSharp/TensorFlow.NET/blob/master/test/TensorFlowNET.Examples/BasicModels/LinearRegression.cs).
+The full example is [here](https://github.com/SciSharp/TensorFlow.NET-Examples/blob/master/src/TensorFlowNET.Examples/BasicModels/LinearRegression.cs).

--- a/docs/source/LogisticRegression.md
+++ b/docs/source/LogisticRegression.md
@@ -13,4 +13,4 @@ The dependent variable of logistics regression can be two-category or multi-cate
 Softmax regression allows us to handle ![1557035393445](_static\logistic-regression\1557035393445.png) where K is the number of classes.
 
 
-The full example is [here](https://github.com/SciSharp/TensorFlow.NET/blob/master/test/TensorFlowNET.Examples/BasicModels/LogisticRegression.cs).
+The full example is [here](https://github.com/SciSharp/TensorFlow.NET-Examples/blob/master/src/TensorFlowNET.Examples/BasicModels/LogisticRegression.cs).

--- a/docs/source/NearestNeighbor.md
+++ b/docs/source/NearestNeighbor.md
@@ -2,4 +2,4 @@
 
 The nearest neighbour algorithm was one of the first algorithms used to solve the travelling salesman problem. In it, the salesman starts at a random city and repeatedly visits the nearest city until all have been visited. It quickly yields a short tour, but usually not the optimal one.
 
-The full example is [here](https://github.com/SciSharp/TensorFlow.NET/blob/master/test/TensorFlowNET.Examples/BasicModels/NearestNeighbor.cs).
+The full example is [here](https://github.com/SciSharp/TensorFlow.NET-Examples/blob/master/src/TensorFlowNET.Examples/BasicModels/NearestNeighbor.cs).


### PR DESCRIPTION
Some links to the examples were not working. This PR links to the right directory.