### PR TITLE
Check if callContext is null or callContext.Value is null create a new  ThreadLocal with CallContext. 

### DIFF
--- a/src/TensorFlowNET.Keras/Engine/Layer.Apply.cs
+++ b/src/TensorFlowNET.Keras/Engine/Layer.Apply.cs
@@ -14,7 +14,7 @@ namespace Tensorflow.Keras.Engine
         /// <returns></returns>
         public Tensors Apply(Tensors inputs, Tensor state = null, bool training = false)
         {
-            callContext = callContext ?? new ThreadLocal<CallContext>()
+            callContext = callContext?.Value != null ? callContext : new ThreadLocal<CallContext>()
             {
                 Value = new CallContext()
             };


### PR DESCRIPTION
If trying to run predict method from new Thread or Task callContext does not contains Value. This small fix check that check if callContext is null or callContext.Value is null create a new  ThreadLocal with CallContext. 