### PR TITLE
Fix duplicate graph node name

### DIFF
--- a/src/TensorFlowNET.Core/Graphs/Graph.cs
+++ b/src/TensorFlowNET.Core/Graphs/Graph.cs
@@ -280,7 +280,10 @@ namespace Tensorflow
 
             // If a names ends with a '/' it is a "name scope" and we use it as-is,
             // after removing the trailing '/'.
-            name = name.EndsWith("/") ? ops.name_from_scope_name(name) : unique_name(name);
+            // This was causing duplicate graph node name errors, when testing a conv2d autoencoder
+            // https://keras.io/guides/functional_api/#:~:text=keras.,graph%20(DAG)%20of%20layers.
+            // name = name.EndsWith("/") ? ops.name_from_scope_name(name) : unique_name(name);
+            name = name.EndsWith("/") ? unique_name(ops.name_from_scope_name(name)) : unique_name(name);
             var node_def = ops._NodeDef(op_type, name, attrs: attrs);
 
             var input_ops = inputs.Select(x => x.op).ToArray();

--- a/src/TensorFlowNET.Keras/BackendImpl.cs
+++ b/src/TensorFlowNET.Keras/BackendImpl.cs
@@ -354,7 +354,7 @@ namespace Tensorflow.Keras
             var tf_data_format = "NHWC";
             padding = padding.ToUpper();
             strides = new Shape(1, strides[0], strides[1], 1);
-            if (dilation_rate.Equals(new[] { 1, 1 }))
+            if (dilation_rate.Equals(new long[] { 1, 1 }))
                 x = nn_impl.conv2d_transpose(x, kernel, output_shape, strides,
                     padding: padding,
                     data_format: tf_data_format);


### PR DESCRIPTION
testing a conv2d autoencoder from
https://keras.io/guides/functional_api/#:~:text=keras.,graph%20(DAG)%20of%20layers

revealed that layer names ending in / could be duplicated in the graph, preventing the model from being compiled. This fix resolved the duplicate layer name issue.