### PR TITLE
Remove unused dependency

### DIFF
--- a/src/TensorFlowNET.Core/Tensorflow.Binding.csproj
+++ b/src/TensorFlowNET.Core/Tensorflow.Binding.csproj
@@ -92,7 +92,6 @@ https://tensorflownet.readthedocs.io</Description>
 
   <ItemGroup>
     <PackageReference Include="MethodBoundaryAspect.Fody" Version="2.0.144" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Protobuf.Text" Version="0.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>

--- a/test/TensorFlowNET.Keras.UnitTest/PreprocessingTests.cs
+++ b/test/TensorFlowNET.Keras.UnitTest/PreprocessingTests.cs
@@ -7,7 +7,6 @@ using Tensorflow.NumPy;
 using static Tensorflow.KerasApi;
 using Tensorflow;
 using Tensorflow.Keras.Datasets;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace TensorFlowNET.Keras.UnitTest
 {


### PR DESCRIPTION
The dependency on `Microsoft.Extensions.DependencyInjection` is unused and can be safely removed.

This PR fixes #920.