### PR TITLE
Removed use of tf.Status static instance

### DIFF
--- a/src/TensorFlowNET.Core/Sessions/BaseSession.cs
+++ b/src/TensorFlowNET.Core/Sessions/BaseSession.cs
@@ -291,7 +291,7 @@ namespace Tensorflow
         protected override void DisposeUnmanagedResources(IntPtr handle)
         {
             // c_api.TF_CloseSession(handle, tf.Status.Handle);
-            c_api.TF_DeleteSession(handle, tf.Status.Handle);
+            c_api.TF_DeleteSession(handle, c_api.TF_NewStatus());
         }
     }
 }


### PR DESCRIPTION
In multithreading .NET 4.8 applications, sometimes in Session finalizer the method c_api.TF_DeleteSession find f.Status static instance already disposed for some reason. No problem for .NET 6 application or with a single thread. (https://github.com/SciSharp/TensorFlow.NET/issues/912)