### PR TITLE
Fix ConvTraspose2D gradient and register rsqrt gradient.

### DIFF
--- a/src/TensorFlowNET.Core/Gradients/math_grad.cs
+++ b/src/TensorFlowNET.Core/Gradients/math_grad.cs
@@ -639,6 +639,20 @@ namespace Tensorflow.Gradients
             });
         }
 
+        [RegisterGradient("Rsqrt")]
+        public static Tensor[] _RsqrtGrad(Operation op, Tensor[] grads)
+        {
+            var grad = grads[0];
+            var y = op.outputs[0];
+
+            return tf_with(ops.control_dependencies(grads), delegate
+            {
+                y = math_ops.conj(y);
+                var factor = constant_op.constant(-0.5f, dtype: y.dtype);
+                return new Tensor[] { grad * (factor * math_ops.square(y) * y) };
+            });
+        }
+
         [RegisterGradient("Asin")]
         public static Tensor[] _ASinGrad(Operation op, Tensor[] grads)
         {

--- a/src/TensorFlowNET.Core/Keras/Layers/ILayersApi.cs
+++ b/src/TensorFlowNET.Core/Keras/Layers/ILayersApi.cs
@@ -55,6 +55,20 @@ namespace Tensorflow.Keras.Layers
             IRegularizer bias_regularizer = null,
             IRegularizer activity_regularizer = null);
 
+        public ILayer Conv2DTranspose(int filters,
+            Shape kernel_size = null,
+            Shape strides = null,
+            string output_padding = "valid",
+            string data_format = null,
+            Shape dilation_rate = null,
+            string activation = null,
+            bool use_bias = true,
+            string kernel_initializer = null,
+            string bias_initializer = null,
+            string kernel_regularizer = null,
+            string bias_regularizer = null,
+            string activity_regularizer = null);
+
         public ILayer Conv2D(int filters,
             Shape kernel_size = null,
             Shape strides = null,


### PR DESCRIPTION
Fix #974 

It seems that this problem is caused because `unneeded_gradients` is unused.

Besides, `Rsqrt` gradient is not registered and `Conv2DTranspose` is not declared in `ILayersApi`.

This PR resolved the problems above. @Oceania2018 Please have a review, especially the modification of `Tape.ComputeGradient.cs`.