### PR TITLE
Add default value of parameter of keras softmax.

### DIFF
--- a/src/TensorFlowNET.Core/Keras/Layers/ILayersApi.Activation.cs
+++ b/src/TensorFlowNET.Core/Keras/Layers/ILayersApi.Activation.cs
@@ -9,6 +9,7 @@ namespace Tensorflow.Keras.Layers
     {
         public ILayer ELU(float alpha = 0.1f);
         public ILayer SELU();
+        public ILayer Softmax(int axis = -1);
         public ILayer Softmax(Axis axis);
         public ILayer Softplus();
         public ILayer HardSigmoid();

--- a/src/TensorFlowNET.Keras/Layers/LayersApi.Activation.cs
+++ b/src/TensorFlowNET.Keras/Layers/LayersApi.Activation.cs
@@ -11,6 +11,7 @@ namespace Tensorflow.Keras.Layers {
                   => new ELU(new ELUArgs { Alpha = alpha });
             public ILayer SELU ()
                   => new SELU(new LayerArgs { });
+            public ILayer Softmax(int axis = -1) => new Softmax(new SoftmaxArgs { axis = axis });
             public ILayer Softmax ( Axis axis ) => new Softmax(new SoftmaxArgs { axis = axis });
             public ILayer Softplus () => new Softplus(new LayerArgs { });
             public ILayer HardSigmoid () => new HardSigmoid(new LayerArgs { });

--- a/test/TensorFlowNET.Keras.UnitTest/SaveModel/SequentialModelSave.cs
+++ b/test/TensorFlowNET.Keras.UnitTest/SaveModel/SequentialModelSave.cs
@@ -54,7 +54,7 @@ public class SequentialModelSave
             keras.layers.Flatten(),
             keras.layers.Dense(100, "relu"),
             keras.layers.Dense(10),
-            keras.layers.Softmax(1)
+            keras.layers.Softmax()
         });
 
         model.summary();


### PR DESCRIPTION
In python we often use `keras.softmax` without parameters because it set default parameter `axis = -1`.

This PR adds an overload of `keras.softmax` to align the behavior with tensorflow python.