### PR TITLE
Add a Stop_training property 

### DIFF
--- a/src/TensorFlowNET.Core/Keras/Engine/IModel.cs
+++ b/src/TensorFlowNET.Core/Keras/Engine/IModel.cs
@@ -79,5 +79,5 @@ public interface IModel : ILayer
 
     IKerasConfig get_config();
 
-    void set_stopTraining_true();
+    bool Stop_training { get;set; }
 }

--- a/src/TensorFlowNET.Keras/Callbacks/Earlystopping.cs
+++ b/src/TensorFlowNET.Keras/Callbacks/Earlystopping.cs
@@ -95,7 +95,7 @@ public class EarlyStopping: ICallback
         if (_wait >= _paitence && epoch > 0)
         {
             _stopped_epoch = epoch;
-            _parameters.Model.set_stopTraining_true();
+            _parameters.Model.Stop_training = true;
             if (_restore_best_weights && _best_weights != null)
             {
                 if (_verbose > 0)

--- a/src/TensorFlowNET.Keras/Engine/Model.cs
+++ b/src/TensorFlowNET.Keras/Engine/Model.cs
@@ -39,6 +39,12 @@ namespace Tensorflow.Keras.Engine
             set => optimizer = value;
         }
 
+        public bool Stop_training
+        {
+            get => stop_training;
+            set => stop_training = value;
+        }
+
         public Model(ModelArgs args)
             : base(args)
         {
@@ -145,10 +151,5 @@ namespace Tensorflow.Keras.Engine
             return children;
         }
 
-
-        void IModel.set_stopTraining_true()
-        {
-            stop_training = true;
-        }
     }
 }


### PR DESCRIPTION
Adding a Stop_training property to set stop_training may be more elegant instead of define a set_stoptraining_true function.