### PR TITLE
Fix the bug of non-convergence when use SparseCategoricalCrossentropy

### DIFF
--- a/src/TensorFlowNET.Keras/Losses/SparseCategoricalCrossentropy.cs
+++ b/src/TensorFlowNET.Keras/Losses/SparseCategoricalCrossentropy.cs
@@ -4,17 +4,21 @@ namespace Tensorflow.Keras.Losses
 {
     public class SparseCategoricalCrossentropy : LossFunctionWrapper, ILossFunc
     {
+        private bool _from_logits = false;
         public SparseCategoricalCrossentropy(
             bool from_logits = false,
             string reduction = null,
             string name = null) :
-            base(reduction: reduction, name: name == null ? "sparse_categorical_crossentropy" : name){ }
+            base(reduction: reduction, name: name == null ? "sparse_categorical_crossentropy" : name)
+        {
+            _from_logits = from_logits;
+        }
 
         public override Tensor Apply(Tensor target, Tensor output, bool from_logits = false, int axis = -1)
         {
             target = tf.cast(target, dtype: TF_DataType.TF_INT64);
 
-            if (!from_logits)
+            if (!_from_logits)
             {
                 var epsilon = tf.constant(KerasApi.keras.backend.epsilon(), output.dtype);
                 output = tf.clip_by_value(output, epsilon, 1 - epsilon);


### PR DESCRIPTION
I found that the reason why the model does not converge lies in this SparseCategoricalCrossentropy function, when I change it to CategoricalCrossentropy and do ont-hot on y_train it works well. So the problem is this loss function. I found the from_logits used by the Apply function is not the from_logits that comes in the constructor. So it will always be false even if we specify it as true when we use SparseCategoricalCrossentropy.