### PR TITLE
Add the constructor of NDArray which reuses memory

### DIFF
--- a/src/TensorFlowNET.Core/NumPy/Persistence/NpyFormat.cs
+++ b/src/TensorFlowNET.Core/NumPy/Persistence/NpyFormat.cs
@@ -70,7 +70,7 @@ public class NpyFormat
         if (type == typeof(bool))
             return "|b1";
         else if (type == typeof(byte))
-            return "|i1";
+            return "|u1";
         else if (type == typeof(short))
             return "<i2";
         else if (type == typeof(int))

--- a/src/TensorFlowNET.Core/Numpy/NDArray.Creation.cs
+++ b/src/TensorFlowNET.Core/Numpy/NDArray.Creation.cs
@@ -8,6 +8,7 @@ namespace Tensorflow.NumPy
 {
     public partial class NDArray
     {
+        protected NDArray() { }
         public NDArray(bool value) : base(value) => NewEagerTensorHandle(); 
         public NDArray(byte value) : base(value) => NewEagerTensorHandle();
         public NDArray(short value) : base(value) => NewEagerTensorHandle();
@@ -56,6 +57,20 @@ namespace Tensorflow.NumPy
                 double val => new NDArray(val),
                 _ => throw new NotImplementedException("")
             };
+
+        /// <summary>
+        /// Reuse the existing memory instead of copying it.
+        /// </summary>
+        /// <param name="data_ptr"></param>
+        /// <param name="shape"></param>
+        /// <param name="dtype"></param>
+        /// <param name="deallocator"></param>
+        protected void InitWithExistingMemory(IntPtr data_ptr, Shape shape, TF_DataType dtype, c_api.DeallocatorV2 deallocator)
+        {
+            _handle = c_api.TF_NewTensor(TF_DataType.TF_STRING, shape.dims, shape.ndim, data_ptr, (ulong)(shape.size * dtype.get_datatype_size()), deallocator, IntPtr.Zero);
+            tensor_util.DangerousManuallySetTensorDType(_handle, dtype);
+            NewEagerTensorHandle();
+        }
 
         void NewEagerTensorHandle()
         {

--- a/src/TensorFlowNET.Core/Operations/array_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/array_ops.cs
@@ -417,7 +417,7 @@ namespace Tensorflow
                 {
                     TF_DataType.TF_DOUBLE => constant(1.0d),
                     TF_DataType.TF_FLOAT => constant(1.0f),
-                    _ => constant(1)
+                    _ => constant(1, dtype)
                 };
 
                 if (shape.ndim == 0)

--- a/src/TensorFlowNET.Core/Tensors/c_api.tensor.cs
+++ b/src/TensorFlowNET.Core/Tensors/c_api.tensor.cs
@@ -71,7 +71,7 @@ namespace Tensorflow
         /// <param name="deallocator_arg"></param>
         /// <returns></returns>
         [DllImport(TensorFlowLibName)]
-        public static extern SafeTensorHandle TF_NewTensor(TF_DataType dataType, long[] dims, int num_dims, IntPtr data, ulong len, Deallocator deallocator, IntPtr deallocator_arg);
+        public static extern SafeTensorHandle TF_NewTensor(TF_DataType dataType, long[] dims, int num_dims, IntPtr data, ulong len, DeallocatorV2 deallocator, IntPtr deallocator_arg);
 
         public static unsafe SafeTensorHandle TF_NewTensor(byte[] data, Shape shape, TF_DataType dtype)
         {
@@ -146,6 +146,15 @@ namespace Tensorflow
         /// <returns></returns>
         [DllImport(TensorFlowLibName)]
         public static extern TF_DataType TF_TensorType(SafeTensorHandle tensor);
+
+        /// <summary>
+        /// Set a new shape for the Tensor. Note that this API only works after tf2.11.
+        /// </summary>
+        /// <param name="tensor"></param>
+        /// <param name="dims"></param>
+        /// <param name="num_dims"></param>
+        [DllImport(TensorFlowLibName)]
+        public static extern void TF_SetShape(SafeTensorHandle tensor, long[] dims, int num_dims);
 
         /// <summary>
         /// Return the size in bytes required to encode a string `len` bytes long into a


### PR DESCRIPTION
This PR made the following changes:

1. Fix the error when saving NDArray with dtype=byte.
2. Add a protected constructor for NDArray, which allows to reuse the existing memory to create a NDArray.