### PR TITLE
fix: error when set the activation of keras.layers.Conv2DTranspose to null.

### DIFF
--- a/src/TensorFlowNET.Keras/Activations.cs
+++ b/src/TensorFlowNET.Keras/Activations.cs
@@ -77,6 +77,10 @@ namespace Tensorflow.Keras
 
         public Activation GetActivationFromName(string name)
         {
+            if (name == null)
+            {
+                return _linear;
+            }
             if (!_nameActivationMap.TryGetValue(name, out var res))
             {
                 throw new Exception($"Activation {name} not found");


### PR DESCRIPTION
Solve 1st problem of #1012

The bug is caused by the unchecked variable in GetActivationFromName().

In original TensorFlow, the corresponding method just [returns the 'linear' function](https://github.com/tensorflow/tensorflow/blob/f5157cf2fefe18ffd82a50df4b1d18fd39631123/tensorflow/python/keras/activations.py#LL594C5-L594C12) when encountering this null situation. 

I solved the problem in their way.

Thanks!

