### PR TITLE
fix: can't implement len for KerasShapesWrapper & Add bias implement to Conv2DTranspose.Call()

### DIFF
--- a/src/TensorFlowNET.Keras/Layers/Convolution/Conv2DTranspose.cs
+++ b/src/TensorFlowNET.Keras/Layers/Convolution/Conv2DTranspose.cs
@@ -62,7 +62,7 @@ namespace Tensorflow.Keras.Layers
         public override void build(KerasShapesWrapper input_shape)
         {
             var single_shape = input_shape.ToSingleShape();
-            if (len(input_shape) != 4)
+            if (len(single_shape) != 4)
                 throw new ValueError($"Inputs should have rank 4. Received input shape: {input_shape}");
 
             var channel_axis = _get_channel_axis();
@@ -138,7 +138,10 @@ namespace Tensorflow.Keras.Layers
             }
 
             if (use_bias)
-                throw new NotImplementedException("");
+                tf.nn.bias_add(
+                    outputs,
+                    bias,
+                    data_format: conv_utils.convert_data_format(data_format, ndim: 4));
 
             if (activation != null)
                 return activation.Apply(outputs);


### PR DESCRIPTION
Solve 2nd problem of #1012

Before solving the issue, I found another bug in Conv2DTranspose.build(). The len() cannot be used for input_shape after the commit 747e658, which change the type of input_shape from Shape to KerasShapesWrapper. I solved it by using len(single_shape) instead of len(input_shape), where single_shape = input_shape.ToSingleShape().

Back to the issue, the NotImplementedException raised because the lack of implement to handle 'use_bias' in 'Call' process of Conv2DTranspose. I add the code referring [original TensorFlow](https://github.com/tensorflow/tensorflow/blob/ab388e4485dab64a3a0c421a564a358b4d3381f2/tensorflow/python/keras/layers/convolutional.py#LL1335C18-L1335C18).

Thanks!