### PR TITLE
fix: A new feature for NDArray.max 

### DIFF
--- a/src/TensorFlowNET.Core/NumPy/Numpy.Math.cs
+++ b/src/TensorFlowNET.Core/NumPy/Numpy.Math.cs
@@ -28,7 +28,16 @@ namespace Tensorflow.NumPy
         public static NDArray multiply(NDArray x1, NDArray x2) => new NDArray(tf.multiply(x1, x2));
 
         [AutoNumPy]
-        public static NDArray maximum(NDArray x1, NDArray x2) => new NDArray(tf.maximum(x1, x2));
+        //public static NDArray maximum(NDArray x1, NDArray x2) => new NDArray(tf.maximum(x1, x2));
+        public static NDArray maximum(NDArray x1, NDArray x2, int? axis = null)
+        {
+            var maxValues = tf.maximum(x1, x2);
+            if (axis.HasValue)
+            {
+                maxValues = tf.reduce_max(maxValues, axis: axis.Value);
+            }
+            return new NDArray(maxValues);
+        }
 
         [AutoNumPy]
         public static NDArray minimum(NDArray x1, NDArray x2) => new NDArray(tf.minimum(x1, x2));

--- a/test/TensorFlowNET.UnitTest/Numpy/Math.Test.cs
+++ b/test/TensorFlowNET.UnitTest/Numpy/Math.Test.cs
@@ -65,5 +65,17 @@ namespace TensorFlowNET.UnitTest.NumPy
             var y = np.power(x, 3);
             Assert.AreEqual(y, new[] { 0, 1, 8, 27, 64, 125 });
         }
+         [TestMethod]
+        public void maximum()
+        {
+            var x1 = new NDArray(new[,] { { 1, 2, 3 }, { 4, 5.1, 6 } });
+            var x2 = new NDArray(new[,] { { 3, 2, 1 }, { 6, 5.1, 4 } });
+            var y = np.maximum(x1,x2);
+            var y1 = np.maximum(x1, x2, axis: 0);
+            var y2 = new NDArray(new[,] { { 3, 2, 3 }, { 6, 5.1, 6 } });
+            var y3 = new NDArray(new[] {  6, 5.1, 6 });
+            Assert.AreEqual(y, y2);
+            Assert.AreEqual(y1, y3);
+        }
     }
 }

--- a/test/TensorFlowNET.UnitTest/Numpy/Math.Test.cs
+++ b/test/TensorFlowNET.UnitTest/Numpy/Math.Test.cs
@@ -66,16 +66,19 @@ namespace TensorFlowNET.UnitTest.NumPy
             Assert.AreEqual(y, new[] { 0, 1, 8, 27, 64, 125 });
         }
          [TestMethod]
-        public void maximum()
+       public void maximum()
         {
             var x1 = new NDArray(new[,] { { 1, 2, 3 }, { 4, 5.1, 6 } });
             var x2 = new NDArray(new[,] { { 3, 2, 1 }, { 6, 5.1, 4 } });
-            var y = np.maximum(x1,x2);
+            var y0 = np.maximum(x1,x2);
             var y1 = np.maximum(x1, x2, axis: 0);
-            var y2 = new NDArray(new[,] { { 3, 2, 3 }, { 6, 5.1, 6 } });
-            var y3 = new NDArray(new[] {  6, 5.1, 6 });
-            Assert.AreEqual(y, y2);
-            Assert.AreEqual(y1, y3);
+            var y2 = np.maximum(x1, x2, axis: 1);
+            var y3 = new NDArray(new[,] { { 3, 2, 3 }, { 6, 5.1, 6 } });
+            var y4 = new NDArray(new[] {  6, 5.1, 6 });
+            var y5 = new NDArray(new[] { 3.0, 6 });
+            Assert.AreEqual(y0, y3);
+            Assert.AreEqual(y1, y4);
+            Assert.AreEqual(y2, y5);
         }
     }
 }


### PR DESCRIPTION
Solve the problem that NDArray.max() does not support max from multiple dimensions and add a TestMethod. #635 

And the NDArray.sum() method has already supported max from multiple dimensions.

Thanks!