### PR TITLE
Improve the API of  LayerNormalization

### DIFF
--- a/src/TensorFlowNET.Core/APIs/tf.nn.cs
+++ b/src/TensorFlowNET.Core/APIs/tf.nn.cs
@@ -17,7 +17,6 @@
 using System.Xml.Linq;
 using Tensorflow.Operations;
 using Tensorflow.Operations.Activation;
-//using static System.Formats.Asn1.AsnWriter;
 using static Tensorflow.Binding;
 
 namespace Tensorflow
@@ -127,6 +126,18 @@ namespace Tensorflow
                     is_training: is_training,
                     name: name,
                     exponential_avg_factor: exponential_avg_factor);
+
+            /// <summary>
+            /// Normalizes a tensor by `mean` and `variance`, and applies (optionally) a`scale` \\(\gamma\\) to it, as well as an `offset` \\(\beta\\).
+            /// </summary>
+            /// <param name="x">A floating point tensor.</param>
+            /// <param name="mean">A mean `Tensor`.</param>
+            /// <param name="variance">A variance `Tensor`.</param>
+            /// <param name="offset"> An offset `Tensor`, often denoted \\(\beta\\) in equations, or NULL. If present, will be added to the normalized tensor.</param>
+            /// <param name="scale"> A scale `Tensor`, often denoted \\(\gamma\\) in equations, or NULL. If present, the scale is applied to the normalized tensor.</param>
+            /// <param name="variance_epsilon"> A small float number to avoid dividing by 0.</param>
+            /// <param name="name">A name for this operation.</param>
+            /// <returns>the normalized, scaled, offset tensor.</returns>
             public Tensor batch_normalization(Tensor x,
                         Tensor mean,
                         Tensor variance,

--- a/src/TensorFlowNET.Core/APIs/tf.nn.cs
+++ b/src/TensorFlowNET.Core/APIs/tf.nn.cs
@@ -14,8 +14,10 @@
    limitations under the License.
 ******************************************************************************/
 
+using System.Xml.Linq;
 using Tensorflow.Operations;
 using Tensorflow.Operations.Activation;
+//using static System.Formats.Asn1.AsnWriter;
 using static Tensorflow.Binding;
 
 namespace Tensorflow
@@ -125,6 +127,22 @@ namespace Tensorflow
                     is_training: is_training,
                     name: name,
                     exponential_avg_factor: exponential_avg_factor);
+            public Tensor batch_normalization(Tensor x,
+                        Tensor mean,
+                        Tensor variance,
+                        Tensor offset,
+                        Tensor scale,
+                        float variance_epsilon,
+                        string name = null)
+            {
+                var inv = math_ops.rsqrt(variance + variance_epsilon);
+                tf_with(ops.name_scope(name, "batchnorm", (x, mean, variance, scale, offset)), scope =>
+                {
+                    if (scale != null) inv *= scale;
+                });
+                if (offset != null) return x * math_ops.cast(inv, x.dtype) + math_ops.cast(offset - mean * inv, dtype: x.dtype);
+                else return x * math_ops.cast(inv, x.dtype) + math_ops.cast(-mean * inv, dtype: x.dtype);
+            }
 
             public Tensor max_pool(Tensor value, int[] ksize, int[] strides, string padding, string data_format = "NHWC", string name = null)
                 => nn_ops.max_pool(value, ksize, strides, padding, data_format: data_format, name: name);

--- a/src/TensorFlowNET.Keras/Layers/Normalization/LayerNormalization.cs
+++ b/src/TensorFlowNET.Keras/Layers/Normalization/LayerNormalization.cs
@@ -153,9 +153,22 @@ namespace Tensorflow.Keras.Layers
             }
             else
             {
+                var input_dtype = inputs.dtype;
+                if ((input_dtype == tf.float16) && DType == tf.float32) inputs = tf.cast(inputs, tf.float32);
+                (Tensor mean, Tensor variance) = tf.nn.moments(inputs, axis, keep_dims: true);
 
+                (Tensor scale, Tensor offset) = (_broadcast(gamma), _broadcast(beta));
+
+                outputs = tf.nn.batch_normalization(
+                inputs,
+                mean,
+                variance,
+                offset: offset,
+                scale: scale,
+                variance_epsilon: epsilon);
+
+                outputs = tf.cast(outputs, input_dtype);
             }
-
             // If some components of the shape got lost due to adjustments, fix that.
             outputs.shape = input_shape;
 


### PR DESCRIPTION
The ` LayerNormalization` didn't work as expected, it throws an `System.NullReferenceException` during runtime.