### PR TITLE
fix: type converting errors when loading imdb dataset

### DIFF
--- a/src/TensorFlowNET.Core/NumPy/NDArray.Implicit.cs
+++ b/src/TensorFlowNET.Core/NumPy/NDArray.Implicit.cs
@@ -107,7 +107,13 @@ namespace Tensorflow.NumPy
         public static implicit operator NDArray(bool value)
             => new NDArray(value);
 
+        public static implicit operator NDArray(byte value)
+            => new NDArray(value);
+
         public static implicit operator NDArray(int value)
+            => new NDArray(value);
+
+        public static implicit operator NDArray(long value)
             => new NDArray(value);
 
         public static implicit operator NDArray(float value)

--- a/src/TensorFlowNET.Core/Operations/array_ops.cs
+++ b/src/TensorFlowNET.Core/Operations/array_ops.cs
@@ -84,8 +84,13 @@ namespace Tensorflow
                     // var shape_tensor = constant_op._tensor_shape_tensor_conversion_function(shape);
                     Tensor zeros = dtype switch
                     {
+                        TF_DataType.TF_BOOL => constant(false),
                         TF_DataType.TF_DOUBLE => constant(0d),
                         TF_DataType.TF_FLOAT => constant(0f),
+                        TF_DataType.TF_INT64 => constant(0L),
+                        TF_DataType.TF_UINT64 => constant((ulong)0),
+                        TF_DataType.TF_INT32 => constant(0),
+                        TF_DataType.TF_UINT32 => constant((uint)0),
                         TF_DataType.TF_INT8 => constant((sbyte)0),
                         TF_DataType.TF_UINT8 => constant((byte)0),
                         _ => constant(0)
@@ -108,9 +113,15 @@ namespace Tensorflow
                             return _constant_if_small(0.0F, shape, dtype, name);
                         case TF_DataType.TF_INT64:
                             return _constant_if_small(0L, shape, dtype, name);
+                        case TF_DataType.TF_UINT64:
+                            return _constant_if_small<ulong>(0, shape, dtype, name);
                         case TF_DataType.TF_INT32:
                             return _constant_if_small(0, shape, dtype, name);
+                        case TF_DataType.TF_UINT32:
+                            return _constant_if_small<uint>(0, shape, dtype, name);
                         case TF_DataType.TF_INT8:
+                            return _constant_if_small<sbyte>(0, shape, dtype, name);
+                        case TF_DataType.TF_UINT8:
                             return _constant_if_small<byte>(0, shape, dtype, name);
                         default:
                             throw new TypeError("can't find type for zeros");

--- a/test/TensorFlowNET.UnitTest/Dataset/DatasetTest.cs
+++ b/test/TensorFlowNET.UnitTest/Dataset/DatasetTest.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Linq;
 using static Tensorflow.Binding;
-using static Tensorflow.KerasApi;
 
 namespace TensorFlowNET.UnitTest.Dataset
 {
@@ -195,20 +194,6 @@ namespace TensorFlowNET.UnitTest.Dataset
             }
 
             Assert.IsFalse(allEqual);
-        }
-        [TestMethod]
-        public void GetData()
-        {
-            var vocab_size = 20000;
-            var dataset = keras.datasets.imdb.load_data(num_words: vocab_size);
-            var x_train = dataset.Train.Item1;
-            Assert.AreEqual(x_train.dims[0], 25000);
-            var y_train = dataset.Train.Item2;
-            Assert.AreEqual(y_train.dims[0], 25000);
-            var x_val = dataset.Test.Item1;
-            Assert.AreEqual(x_val.dims[0], 25000);
-            var y_val = dataset.Test.Item2;
-            Assert.AreEqual(y_val.dims[0], 25000);
         }
     }
 }

--- a/test/TensorFlowNET.UnitTest/Dataset/DatasetTest.cs
+++ b/test/TensorFlowNET.UnitTest/Dataset/DatasetTest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using static Tensorflow.Binding;
+using static Tensorflow.KerasApi;
 
 namespace TensorFlowNET.UnitTest.Dataset
 {
@@ -194,6 +195,20 @@ namespace TensorFlowNET.UnitTest.Dataset
             }
 
             Assert.IsFalse(allEqual);
+        }
+        [TestMethod]
+        public void GetData()
+        {
+            var vocab_size = 20000;
+            var dataset = keras.datasets.imdb.load_data(num_words: vocab_size);
+            var x_train = dataset.Train.Item1;
+            Assert.AreEqual(x_train.dims[0], 25000);
+            var y_train = dataset.Train.Item2;
+            Assert.AreEqual(y_train.dims[0], 25000);
+            var x_val = dataset.Test.Item1;
+            Assert.AreEqual(x_val.dims[0], 25000);
+            var y_val = dataset.Test.Item2;
+            Assert.AreEqual(y_val.dims[0], 25000);
         }
     }
 }


### PR DESCRIPTION
Add some implicit operators and dtype processing cases so that the `imdb` loader can work as expected. 