### PR TITLE
fix: partially fix the bug of load_model

### DIFF
--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/ExponentialArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/ExponentialArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class ExponentialArgs : LayerArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/HardSigmoidArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/HardSigmoidArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class HardSigmoidArgs : LayerArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SELUArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SELUArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class SELUArgs : LayerArgs
+    {
+
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SoftplusArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SoftplusArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class SoftplusArgs : LayerArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SoftsignArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SoftsignArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class SoftsignArgs : LayerArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SwishArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/SwishArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class SwishArgs : LayerArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/TanhArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Activation/TanhArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class TanhArgs : LayerArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Convolution/Conv2DTransposeArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Convolution/Conv2DTransposeArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class Conv2DTransposeArgs : Conv2DArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/AddArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/AddArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class AddArgs : MergeArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/ConcatenateArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/ConcatenateArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class ConcatenateArgs : MergeArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/SubtractArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/SubtractArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class SubtractArgs : MergeArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalAveragePooling1DArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalAveragePooling1DArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class GlobalAveragePooling1DArgs : Pooling1DArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalAveragePooling2DArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalAveragePooling2DArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class GlobalAveragePooling2DArgs : Pooling2DArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalMaxPooling1DArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalMaxPooling1DArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class GlobalMaxPooling1DArgs : Pooling1DArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalMaxPooling2DArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/GlobalMaxPooling2DArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class GlobalMaxPooling2DArgs : Pooling2DArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/MaxPooling1DArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Pooling/MaxPooling1DArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tensorflow.Keras.ArgsDefinition
+{
+    public class MaxPooling1DArgs : Pooling1DArgs
+    {
+    }
+}

--- a/src/TensorFlowNET.Keras/Layers/LayersApi.Activation.cs
+++ b/src/TensorFlowNET.Keras/Layers/LayersApi.Activation.cs
@@ -10,14 +10,14 @@ namespace Tensorflow.Keras.Layers {
             public ILayer ELU ( float alpha = 0.1f )
                   => new ELU(new ELUArgs { Alpha = alpha });
             public ILayer SELU ()
-                  => new SELU(new LayerArgs { });
+                  => new SELU(new SELUArgs { });
             public ILayer Softmax(int axis = -1) => new Softmax(new SoftmaxArgs { axis = axis });
             public ILayer Softmax ( Axis axis ) => new Softmax(new SoftmaxArgs { axis = axis });
-            public ILayer Softplus () => new Softplus(new LayerArgs { });
-            public ILayer HardSigmoid () => new HardSigmoid(new LayerArgs { });
-            public ILayer Softsign () => new Softsign(new LayerArgs { });
-            public ILayer Swish () => new Swish(new LayerArgs { });
-            public ILayer Tanh () => new Tanh(new LayerArgs { });
-            public ILayer Exponential () => new Exponential(new LayerArgs { });
+            public ILayer Softplus () => new Softplus(new SoftplusArgs { });
+            public ILayer HardSigmoid () => new HardSigmoid(new HardSigmoidArgs { });
+            public ILayer Softsign () => new Softsign(new SoftsignArgs { });
+            public ILayer Swish () => new Swish(new SwishArgs { });
+            public ILayer Tanh () => new Tanh(new TanhArgs { });
+            public ILayer Exponential () => new Exponential(new ExponentialArgs { });
       }
 }

--- a/src/TensorFlowNET.Keras/Layers/LayersApi.Merging.cs
+++ b/src/TensorFlowNET.Keras/Layers/LayersApi.Merging.cs
@@ -14,7 +14,7 @@ namespace Tensorflow.Keras.Layers
         /// <param name="axis">Axis along which to concatenate.</param>
         /// <returns></returns>
         public ILayer Concatenate(int axis = -1)
-            => new Concatenate(new MergeArgs
+            => new Concatenate(new ConcatenateArgs
             {
                 Axis = axis
             });

--- a/src/TensorFlowNET.Keras/Layers/LayersApi.cs
+++ b/src/TensorFlowNET.Keras/Layers/LayersApi.cs
@@ -240,7 +240,7 @@ namespace Tensorflow.Keras.Layers
             string kernel_regularizer = null,
             string bias_regularizer = null,
             string activity_regularizer = null)
-                => new Conv2DTranspose(new Conv2DArgs
+                => new Conv2DTranspose(new Conv2DTransposeArgs
                 {
                     Rank = 2,
                     Filters = filters,
@@ -568,7 +568,7 @@ namespace Tensorflow.Keras.Layers
             int? strides = null,
             string padding = "valid",
             string data_format = null)
-            => new MaxPooling1D(new Pooling1DArgs
+            => new MaxPooling1D(new MaxPooling1DArgs
             {
                 PoolSize = pool_size ?? 2,
                 Strides = strides ?? (pool_size ?? 2),
@@ -944,21 +944,21 @@ namespace Tensorflow.Keras.Layers
         /// </summary>
         /// <returns></returns>
         public ILayer Add()
-            => new Add(new MergeArgs { });
+            => new Add(new AddArgs { });
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
         public ILayer Subtract()
-            => new Subtract(new MergeArgs { });
+            => new Subtract(new SubtractArgs { });
 
         /// <summary>
         /// Global max pooling operation for spatial data.
         /// </summary>
         /// <returns></returns>
         public ILayer GlobalAveragePooling2D()
-            => new GlobalAveragePooling2D(new Pooling2DArgs { });
+            => new GlobalAveragePooling2D(new GlobalAveragePooling2DArgs { });
 
         /// <summary>
         /// Global average pooling operation for temporal data.
@@ -968,7 +968,7 @@ namespace Tensorflow.Keras.Layers
         /// </param>
         /// <returns></returns>
         public ILayer GlobalAveragePooling1D(string data_format = "channels_last")
-            => new GlobalAveragePooling1D(new Pooling1DArgs { DataFormat = data_format });
+            => new GlobalAveragePooling1D(new GlobalAveragePooling1DArgs { DataFormat = data_format });
 
         /// <summary>
         /// Global max pooling operation for spatial data.
@@ -977,7 +977,7 @@ namespace Tensorflow.Keras.Layers
         /// channels_last corresponds to inputs with shape (batch, height, width, channels) while channels_first corresponds to inputs with shape (batch, channels, height, width).</param>
         /// <returns></returns>
         public ILayer GlobalAveragePooling2D(string data_format = "channels_last")
-            => new GlobalAveragePooling2D(new Pooling2DArgs { DataFormat = data_format });
+            => new GlobalAveragePooling2D(new GlobalAveragePooling2DArgs { DataFormat = data_format });
 
         /// <summary>
         /// Global max pooling operation for 1D temporal data.
@@ -988,7 +988,7 @@ namespace Tensorflow.Keras.Layers
         /// </param>
         /// <returns></returns>
         public ILayer GlobalMaxPooling1D(string data_format = "channels_last")
-            => new GlobalMaxPooling1D(new Pooling1DArgs { DataFormat = data_format });
+            => new GlobalMaxPooling1D(new GlobalMaxPooling1DArgs { DataFormat = data_format });
 
         /// <summary>
         /// Global max pooling operation for spatial data.
@@ -997,7 +997,7 @@ namespace Tensorflow.Keras.Layers
         /// channels_last corresponds to inputs with shape (batch, height, width, channels) while channels_first corresponds to inputs with shape (batch, channels, height, width).</param>
         /// <returns></returns>
         public ILayer GlobalMaxPooling2D(string data_format = "channels_last")
-            => new GlobalMaxPooling2D(new Pooling2DArgs { DataFormat = data_format });
+            => new GlobalMaxPooling2D(new GlobalMaxPooling2DArgs { DataFormat = data_format });
 
         /// <summary>
         /// Get an weights initializer from its name.


### PR DESCRIPTION
Load_model use reflection to revive LayerArgs and then revive Layer.
https://github.com/SciSharp/TensorFlow.NET/blob/adeed05f64cf033a7d945d97ba4b59bc5ec4aa03/src/TensorFlowNET.Keras/Utils/generic_utils.cs#L64-L69
So each layer's args must be the pattern of {class_name}Args, otherwise it cannot be revived.