### PR TITLE
fix: model does not stop on stop_training == true #1170

### DIFF
--- a/src/TensorFlowNET.Keras/Engine/Model.Fit.cs
+++ b/src/TensorFlowNET.Keras/Engine/Model.Fit.cs
@@ -224,6 +224,10 @@ namespace Tensorflow.Keras.Engine
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
+                if (stop_training)
+                {
+                    break;
+                }
             }
 
             return callbacks.History;
@@ -283,6 +287,10 @@ namespace Tensorflow.Keras.Engine
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
+                if (stop_training)
+                {
+                    break;
+                }
             }
 
             return callbacks.History;
@@ -339,6 +347,10 @@ namespace Tensorflow.Keras.Engine
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
+                if (stop_training)
+                {
+                    break;
+                }
             }
 
             return callbacks.History;


### PR DESCRIPTION
Did not test it, but debugging showed that this is the code that is missing. `stop_training` is only updated but never used.

This solves #1170 