### PR TITLE
fix: Implemented support for loading models with Concatenate layers

### DIFF
--- a/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/MergeArgs.cs
+++ b/src/TensorFlowNET.Core/Keras/ArgsDefinition/Merging/MergeArgs.cs
@@ -1,13 +1,15 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Tensorflow.Keras.ArgsDefinition
 {
     // TODO: complete the implementation
-    public class MergeArgs : LayerArgs
+    public class MergeArgs : AutoSerializeLayerArgs
     {
         public Tensors Inputs { get; set; }
+        [JsonProperty("axis")]
         public int Axis { get; set; }
     }
 }

--- a/src/TensorFlowNET.Core/NumPy/Numpy.Manipulation.cs
+++ b/src/TensorFlowNET.Core/NumPy/Numpy.Manipulation.cs
@@ -31,6 +31,15 @@ namespace Tensorflow.NumPy
         public static NDArray stack(params NDArray[] arrays) => new NDArray(array_ops.stack(arrays));
 
         [AutoNumPy]
+        public static NDArray stack(NDArray[] arrays, int axis = 0) => new NDArray(array_ops.stack(arrays, axis));
+        
+        [AutoNumPy]
+        public static NDArray stack((NDArray, NDArray) tuple, int axis = 0) => new NDArray(array_ops.stack(new[] { tuple.Item1, tuple.Item2 }, axis));
+
+        [AutoNumPy]
+        public static NDArray stack((NDArray, NDArray, NDArray) tuple, int axis = 0) => new NDArray(array_ops.stack(new[] { tuple.Item1, tuple.Item2, tuple.Item3 }, axis));
+
+        [AutoNumPy]
         public static NDArray moveaxis(NDArray array, Axis source, Axis destination) => new NDArray(array_ops.moveaxis(array, source, destination));
     }
 }

--- a/src/TensorFlowNET.Keras/Layers/Merging/Concatenate.cs
+++ b/src/TensorFlowNET.Keras/Layers/Merging/Concatenate.cs
@@ -39,6 +39,7 @@ namespace Tensorflow.Keras.Layers
                 shape_set.Add(shape);
             }*/
             _buildInputShape = input_shape;
+            built = true;
         }
 
         protected override Tensors _merge_function(Tensors inputs)

--- a/src/TensorFlowNET.Keras/Utils/generic_utils.cs
+++ b/src/TensorFlowNET.Keras/Utils/generic_utils.cs
@@ -112,12 +112,23 @@ namespace Tensorflow.Keras.Utils
             foreach (var token in layersToken)
             {
                 var args = deserialize_layer_args(token["class_name"].ToObject<string>(), token["config"]);
+
+                List<NodeConfig> nodeConfig = null; //python tensorflow sometimes exports inbound nodes in an extra nested array
+                if (token["inbound_nodes"].Count() > 0 && token["inbound_nodes"][0].Count() > 0 && token["inbound_nodes"][0][0].Count() > 0)
+                {
+                    nodeConfig = token["inbound_nodes"].ToObject<List<List<NodeConfig>>>().FirstOrDefault() ?? new List<NodeConfig>();
+                }
+                else
+                {
+                    nodeConfig = token["inbound_nodes"].ToObject<List<NodeConfig>>();
+                }
+
                 config.Layers.Add(new LayerConfig()
                 {
                     Config = args, 
                     Name = token["name"].ToObject<string>(), 
                     ClassName = token["class_name"].ToObject<string>(), 
-                    InboundNodes = token["inbound_nodes"].ToObject<List<NodeConfig>>()
+                    InboundNodes = nodeConfig,
                 });
             }
             config.InputLayers = json["input_layers"].ToObject<List<NodeConfig>>();

--- a/test/TensorFlowNET.Keras.UnitTest/Layers/Layers.Merging.Test.cs
+++ b/test/TensorFlowNET.Keras.UnitTest/Layers/Layers.Merging.Test.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using Tensorflow.NumPy;
 using static Tensorflow.KerasApi;
 
@@ -8,12 +9,16 @@ namespace Tensorflow.Keras.UnitTest.Layers
     public class LayersMergingTest : EagerModeTestBase
     {
         [TestMethod]
-        public void Concatenate()
+        [DataRow(1, 4, 1, 5)]
+        [DataRow(2, 2, 2, 5)]
+        [DataRow(3, 2, 1, 10)]
+        public void Concatenate(int axis, int shapeA, int shapeB, int shapeC)
         {
-            var x = np.arange(20).reshape((2, 2, 5));
-            var y = np.arange(20, 30).reshape((2, 1, 5));
-            var z = keras.layers.Concatenate(axis: 1).Apply(new Tensors(x, y));
-            Assert.AreEqual((2, 3, 5), z.shape);
+            var x = np.arange(10).reshape((1, 2, 1, 5));
+            var y = np.arange(10, 20).reshape((1, 2, 1, 5));
+            var z = keras.layers.Concatenate(axis: axis).Apply(new Tensors(x, y));
+            Assert.AreEqual((1, shapeA, shapeB, shapeC), z.shape);
         }
+
     }
 }


### PR DESCRIPTION
This is my first serious pullrequest so please be gentle :)

The `tf.keras.models.load_model()` is now able to load models with this layer type.

There was a lot missing but I have a Unet model running in the field that now fully works.

I had some weird troubles with python tensorflow (im using 2.11.1) that savemodel would put the inbound nodes for concatenate layers in an extra nested array. My call in python looks like:
```python
comb = layers.Concatenate(axis=3, name=name+"_concat1")([concat_layer,conv])
```
This would create the following output in the manifest (notice the extra `[` and `]`:
```json
{
  "class_name": "Concatenate",
  "config": {
    "name": "EXP_1_concat1",
    "trainable": true,
    "dtype": "float32",
    "axis": 3
  },
  "name": "EXP_1_concat1",
  "inbound_nodes": [
    [
  	[
  	  "CNT_4_conv_2",
  	  0,
  	  0,
  	  {}
  	],
  	[
  	  "EXP_1_conv_0",
  	  0,
  	  0,
  	  {}
  	]
    ]
  ]
},
```
so thats why i added an extra check in generic_utils.cs for this extra nest. I would love some feedback on the implementation of this check and if it's the correct way to do.

And lastly, since concatenate layers have more than 1 input node we need a List<NodeConfig> when processing nodes in Functional.FromConfig.cs.

I also added a few tests to make sure that saving and loading a model with concatenate layers is the same (this was not the case before my changes).